### PR TITLE
add build and dist to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.egg-info
+/build
+/dist


### PR DESCRIPTION
These two directories get created after running 
python setup.py install

They shouldn't be checked into the repo.
