### PR TITLE
Included the Group in the Replica Set Name

### DIFF
--- a/tyr/servers/mongo/member.py
+++ b/tyr/servers/mongo/member.py
@@ -33,7 +33,8 @@ class MongoReplicaSetMember(MongoNode):
 
         with self.chef_api:
 
-            replica_set = 'rs' + str(self.replica_set)
+            group = self.cluster.split('-')[0]
+            replica_set = group + '-rs' + str(self.replica_set)
 
             self.chef_node.attributes.set_dotted('mongodb.replicaset_name', replica_set)
             self.log.info('Set the replica set name to "{name}"'.format(


### PR DESCRIPTION
Instead of the replica set name being set to `rs1`, it will now be set to something like `monolith-rs1`.

&mdash; @citruspi
