### PR TITLE
Cleanup Server Arguments

### DIFF
--- a/tyr/clusters/mongo.py
+++ b/tyr/clusters/mongo.py
@@ -15,7 +15,7 @@ class MongoCluster(object):
     ch.setFormatter(formatter)
     log.addHandler(ch)
 
-    def __init__(self, group = None, type_ = None, instance_type = None,
+    def __init__(self, group = None, server_type = None, instance_type = None,
                     environment = None, ami = None, region = None, role = None,
                     keypair = None, chef_path = None, replica_set = None,
                     security_groups = None, block_devices = None,
@@ -26,7 +26,7 @@ class MongoCluster(object):
 
         self.instance_type = instance_type
         self.group = group
-        self.type_ = type_
+        self.server_type = server_type
         self.environment = environment
         self.ami = ami
         self.region = region
@@ -57,7 +57,7 @@ class MongoCluster(object):
 
         for i in range(self.data_nodes):
 
-            node = MongoDataNode(group = self.group, type_ = self.type_,
+            node = MongoDataNode(group = self.group, server_type = self.server_type,,
                                     instance_type = self.instance_type,
                                     environment = self.environment,
                                     ami = self.ami, region = self.region,
@@ -79,7 +79,7 @@ class MongoCluster(object):
 
             self.log.info('Including Arbiter Node')
 
-            node = MongoArbiterNode(group = self.group, type_ = self.type_,
+            node = MongoArbiterNode(group = self.group, server_type = self.server_type,
                                     instance_type = self.instance_type,
                                     environment = self.environment,
                                     ami = self.ami, region = self.region,

--- a/tyr/servers/mongo/arbiter.py
+++ b/tyr/servers/mongo/arbiter.py
@@ -9,13 +9,13 @@ class MongoArbiterNode(MongoReplicaSetMember):
     CHEF_RUNLIST = ['role[RoleMongo]']
     CHEF_MONGODB_TYPE = 'arbiter'
 
-    def __init__(self, group = None, type_ = None, instance_type = None,
+    def __init__(self, group = None, server_type = None, instance_type = None,
                     environment = None, ami = None, region = None, role = None,
                     keypair = None, availability_zone = None,
                     security_groups = None, block_devices = None,
                     chef_path = None, replica_set = None):
 
-        super(MongoArbiterNode, self).__init__(group, type_, instance_type,
+        super(MongoArbiterNode, self).__init__(group, server_type, instance_type,
                                                 environment, ami, region, role,
                                                 keypair, availability_zone,
                                                 security_groups, block_devices,

--- a/tyr/servers/mongo/data.py
+++ b/tyr/servers/mongo/data.py
@@ -10,14 +10,14 @@ class MongoDataNode(MongoReplicaSetMember):
     CHEF_RUNLIST = ['role[RoleMongo]']
     CHEF_MONGODB_TYPE = 'data'
 
-    def __init__(self, group = None, type_ = None, instance_type = None,
+    def __init__(self, group = None, server_type = None, instance_type = None,
                     environment = None, ami = None, region = None, role = None,
                     keypair = None, availability_zone = None,
                     security_groups = None, block_devices = None,
                     chef_path = None, replica_set = None,
                     data_volume_size = None, data_volume_iops = None):
 
-        super(MongoDataNode, self).__init__(group, type_, instance_type,
+        super(MongoDataNode, self).__init__(group, server_type, instance_type,
                                             environment, ami, region, role,
                                             keypair, availability_zone,
                                             security_groups, block_devices,

--- a/tyr/servers/mongo/data_warehousing.py
+++ b/tyr/servers/mongo/data_warehousing.py
@@ -15,14 +15,14 @@ class MongoDataWarehousingNode(MongoReplicaSetMember):
     CHEF_RUNLIST = ['role[RoleMongo]']
     CHEF_MONGODB_TYPE = 'data_warehousing'
 
-    def __init__(self, group = None, type_ = None, instance_type = None,
+    def __init__(self, group = None, server_type = None, instance_type = None,
                     environment = None, ami = None, region = None, role = None,
                     keypair = None, availability_zone = None,
                     security_groups = None, block_devices = None,
                     chef_path = None, replica_set = None,
                     data_volume_size = None):
 
-        super(MongoDataWarehousingNode, self).__init__(group, type_,
+        super(MongoDataWarehousingNode, self).__init__(group, server_type,
                                                         instance_type,
                                                         environment,  ami,
                                                         region, role, keypair,

--- a/tyr/servers/mongo/member.py
+++ b/tyr/servers/mongo/member.py
@@ -2,13 +2,13 @@ from node import MongoNode
 
 class MongoReplicaSetMember(MongoNode):
 
-    def __init__(self, group = None, type_ = None, instance_type = None,
+    def __init__(self, group = None, server_type = None, instance_type = None,
                     environment = None, ami = None, region = None, role = None,
                     keypair = None, availability_zone = None,
                     security_groups = None, block_devices = None,
                     chef_path = None, replica_set = None):
 
-        super(MongoReplicaSetMember, self).__init__(group, type_, instance_type,
+        super(MongoReplicaSetMember, self).__init__(group, server_type, instance_type,
                                                     environment, ami, region,
                                                     role, keypair,
                                                     availability_zone,

--- a/tyr/servers/mongo/node.py
+++ b/tyr/servers/mongo/node.py
@@ -2,22 +2,22 @@ from tyr.servers.server import Server
 
 class MongoNode(Server):
 
-    TYPE_ = 'mongo'
+    SERVER_TYPE = 'mongo'
 
     CHEF_RUNLIST = ['role[RoleMongo]']
     CHEF_MONGODB_TYPE = 'generic'
 
     IAM_ROLE_POLICIES = ['allow-volume-control']
 
-    def __init__(self, group = None, type_ = None, instance_type = None,
+    def __init__(self, group = None, server_type = None, instance_type = None,
                     environment = None, ami = None, region = None, role = None,
                     keypair = None, availability_zone = None,
                     security_groups = None, block_devices = None,
                     chef_path = None):
 
-        if type_ is None: type_ = self.TYPE_
+        if server_type is None: server_type = self.SERVER_TYPE
 
-        super(MongoNode, self).__init__(group, type_, instance_type,
+        super(MongoNode, self).__init__(group, server_type, instance_type,
                                         environment, ami, region, role,
                                         keypair, availability_zone,
                                         security_groups, block_devices,

--- a/tyr/servers/server.py
+++ b/tyr/servers/server.py
@@ -18,14 +18,14 @@ class Server(object):
 
     CHEF_RUNLIST=['role[RoleBase]']
 
-    def __init__(self, group=None, type_=None, instance_type=None,
+    def __init__(self, group=None, server_type=None, instance_type=None,
                     environment=None, ami=None, region=None, role=None,
                     keypair=None, availability_zone=None, security_groups=None,
                     block_devices=None, chef_path=None):
 
         self.instance_type = instance_type
         self.group = group
-        self.type_ = type_
+        self.server_type= server_type
         self.environment = environment
         self.ami = ami
         self.region = region
@@ -61,8 +61,8 @@ class Server(object):
             self.log.warn('No Instance Type provided')
             self.instance_type = 'm3.medium'
 
-        self.log.info('Using Instance Type "{type_}"'.format(
-                                                    type_ = self.instance_type))
+        self.log.info('Using Instance Type "{instance_type}"'.format(
+                                            instance_type = self.instance_type))
 
         if self.group is None:
             self.log.warn('No group provided')
@@ -71,12 +71,12 @@ class Server(object):
         self.log.info('Using group "{group}"'.format(
                         group = self.group))
 
-        if self.type_ is None:
+        if self.server_type is None:
             self.log.warn('No type provided')
             raise InvalidCluster('A type must be specified.')
 
-        self.log.info('Using type "{type_}"'.format(
-                        type_ = self.type_))
+        self.log.info('Using type "{server_type}"'.format(
+                        server_type = self.server_type))
 
 
         if self.environment is None:
@@ -242,10 +242,10 @@ class Server(object):
     @property
     def envcl(self):
 
-        template = '{environment}-{group}-{type_}'
+        template = '{environment}-{group}-{server_type}'
         envcl = template.format(environment = self.environment[0],
                                   group = self.group,
-                                  type_ = self.type_)
+                                  server_type = self.server_type)
 
         self.log.info('Using envcl {envcl}'.format(envcl = envcl))
 
@@ -327,7 +327,7 @@ chef-client -S 'http://chef.app.hudl.com/' -N {name} -L {logfile}"""
         tags['Name'] = self.name
         tags['Environment'] = self.environment
         tags['Group'] = self.group
-        tags['Role'] = 'Role'+self.type_.capitalize()
+        tags['Role'] = 'Role'+self.server_type.capitalize()
 
         self.log.info('Using instance tags {tags}'.format(tags = tags))
 


### PR DESCRIPTION
The primary change is that instead of passing in an argument `cluster` when a server is created, there are now two separate arguments `group` and `type_`. Default values can be set for `type_`.

So if a user wanted to create a MongoDB data node, the code would look like this:

```
n = MongoDataNode(group='monolith')
```

I've also removed the `dry` and `verbose` arguments since I don't respect them either way.
