### PR TITLE
Set Default MongoDB Node Security Groups

### DIFF
--- a/tyr/servers/mongo/node.py
+++ b/tyr/servers/mongo/node.py
@@ -23,6 +23,22 @@ class MongoNode(Server):
                                         security_groups, block_devices,
                                         chef_path)
 
+    def configure(self):
+
+        super(MongoNode, self).configure()
+
+        # This is just a temporary fix to override the default security
+        # groups for MongoDB nodes until the security_groups argument
+        # is removed.
+        self.security_groups = [
+            'management',
+            'chef-nodes',
+            self.envcl,
+            '{env}-mongo-management'.format(env = self.environment[0])
+        ]
+
+        self.resolve_security_groups()
+
     def run_mongo(self, command):
 
         template = 'mongo --port 27018 --eval "JSON.stringify({command})"'


### PR DESCRIPTION
This overrides the `security_groups` argument (even if explicitly set by the user) to set the security groups for any MongoDB node to
- `management`
- `chef-nodes`
- `{env}-{group}-{server_type}`
- `{env}-mongo-management`

where `{env}` is the first character of the `self.environment` variable.

In the future, the `security_groups` argument will be remove to avoid confusion.
