### PR TITLE
Argument for MongoDB Package Version

### DIFF
--- a/tyr/clusters/mongo.py
+++ b/tyr/clusters/mongo.py
@@ -20,7 +20,7 @@ class MongoCluster(object):
                     keypair = None, chef_path = None, replica_set = None,
                     security_groups = None, block_devices = None,
                     data_volume_size=None, data_volume_iops=None,
-                    data_nodes=None, role_policies=None):
+                    data_nodes=None, role_policies=None, mongodb_version=None):
 
         self.nodes = []
 
@@ -40,6 +40,7 @@ class MongoCluster(object):
         self.data_volume_iops = data_volume_iops
         self.data_nodes = data_nodes
         self.role_policies = role_policies
+        self.mongodb_version = mongodb_version
 
     def provision(self):
 
@@ -69,7 +70,8 @@ class MongoCluster(object):
                                     availability_zone = zones[i],
                                     data_volume_size = self.data_volume_size,
                                     data_volume_iops = self.data_volume_iops,
-                                    role_policies = role_policies)
+                                    role_policies = role_policies,
+                                    mongodb_version = mongodb_version)
 
             node.autorun()
 
@@ -89,7 +91,8 @@ class MongoCluster(object):
                                     security_groups = self.security_groups,
                                     block_devices = self.block_devices,
                                     availability_zone = zones[i+1],
-                                    role_policies = role_policies)
+                                    role_policies = role_policies,
+                                    mongodb_version = mongodb_version)
 
             node.autorun()
 

--- a/tyr/servers/mongo/arbiter.py
+++ b/tyr/servers/mongo/arbiter.py
@@ -13,13 +13,15 @@ class MongoArbiterNode(MongoReplicaSetMember):
                     environment = None, ami = None, region = None, role = None,
                     keypair = None, availability_zone = None,
                     security_groups = None, block_devices = None,
-                    chef_path = None, replica_set = None):
+                    chef_path = None, replica_set = None,
+                    mongodb_version = None):
 
         super(MongoArbiterNode, self).__init__(group, server_type, instance_type,
                                                 environment, ami, region, role,
                                                 keypair, availability_zone,
                                                 security_groups, block_devices,
-                                                chef_path, replica_set)
+                                                chef_path, replica_set,
+                                                mongodb_version)
 
     def bake(self):
 

--- a/tyr/servers/mongo/data.py
+++ b/tyr/servers/mongo/data.py
@@ -15,13 +15,15 @@ class MongoDataNode(MongoReplicaSetMember):
                     keypair = None, availability_zone = None,
                     security_groups = None, block_devices = None,
                     chef_path = None, replica_set = None,
-                    data_volume_size = None, data_volume_iops = None):
+                    data_volume_size = None, data_volume_iops = None,
+                    mongodb_version = None):
 
         super(MongoDataNode, self).__init__(group, server_type, instance_type,
                                             environment, ami, region, role,
                                             keypair, availability_zone,
                                             security_groups, block_devices,
-                                            chef_path, replica_set)
+                                            chef_path, replica_set,
+                                            mongodb_version)
 
         self.data_volume_size = data_volume_size
         self.data_volume_iops = data_volume_iops

--- a/tyr/servers/mongo/data_warehousing.py
+++ b/tyr/servers/mongo/data_warehousing.py
@@ -20,7 +20,7 @@ class MongoDataWarehousingNode(MongoReplicaSetMember):
                     keypair = None, availability_zone = None,
                     security_groups = None, block_devices = None,
                     chef_path = None, replica_set = None,
-                    data_volume_size = None):
+                    data_volume_size = None, mongodb_version = None):
 
         super(MongoDataWarehousingNode, self).__init__(group, server_type,
                                                         instance_type,
@@ -30,7 +30,8 @@ class MongoDataWarehousingNode(MongoReplicaSetMember):
                                                         security_groups,
                                                         block_devices,
                                                         chef_path,
-                                                        replica_set)
+                                                        replica_set,
+                                                        mongodb_version)
 
         self.data_volume_size = data_volume_size
 

--- a/tyr/servers/mongo/member.py
+++ b/tyr/servers/mongo/member.py
@@ -6,14 +6,16 @@ class MongoReplicaSetMember(MongoNode):
                     environment = None, ami = None, region = None, role = None,
                     keypair = None, availability_zone = None,
                     security_groups = None, block_devices = None,
-                    chef_path = None, replica_set = None):
+                    chef_path = None, replica_set = None,
+                    mongodb_version = None):
 
         super(MongoReplicaSetMember, self).__init__(group, server_type, instance_type,
                                                     environment, ami, region,
                                                     role, keypair,
                                                     availability_zone,
                                                     security_groups,
-                                                    block_devices, chef_path)
+                                                    block_devices, chef_path,
+                                                    mongodb_version)
 
         self.replica_set = replica_set
 


### PR DESCRIPTION
This adds an argument to MongoDB nodes which allows the user to set the package version of MongoDB they would like installed.

The default value is `2.4.13`.
