### PR TITLE
Mongo Config Node Support

### DIFF
--- a/tyr/servers/mongo/__init__.py
+++ b/tyr/servers/mongo/__init__.py
@@ -1,3 +1,4 @@
 from data import MongoDataNode
 from arbiter import MongoArbiterNode
 from data_warehousing import MongoDataWarehousingNode
+from config import MongoConfigNode

--- a/tyr/servers/mongo/config.py
+++ b/tyr/servers/mongo/config.py
@@ -1,0 +1,52 @@
+from node import MongoNode
+
+class MongoConfigNode(MongoNode):
+
+    NAME_TEMPLATE = '{envcl}-cfg-{zone}'
+    NAME_SEARCH_PREFIX = '{envcl}-cfg-'
+    NAME_AUTO_INDEX = False
+
+    CHEF_RUNLIST = ['role[RoleMongo]']
+    CHEF_MONGODB_TYPE = 'config'
+
+    def __init__(self, group = None, server_type = None, instance_type = None,
+                    environment = None, ami = None, region = None, role = None,
+                    keypair = None, availability_zone = None,
+                    security_groups = None, block_devices = None,
+                    chef_path = None):
+
+        super(MongoConfigNode, self).__init__(group, server_type, instance_type,
+                                                environment, ami, region, role,
+                                                keypair, availability_zone,
+                                                security_groups,
+                                                block_devices, chef_path)
+
+    def bake(self):
+
+        super(MongoConfigNode, self).bake()
+
+        with self.chef_api:
+
+            self.chef_node.attributes.set_dotted('hudl_ebs.volumes', [
+                {
+                    'user': 'mongod',
+                    'group': 'mongod',
+                    'size': 5,
+                    'iops': 0,
+                    'device': '/dev/xvdg',
+                    'mount': '/volr/journal'
+                },
+                {
+                    'user': 'mongod',
+                    'group': 'mongod',
+                    'size': 5,
+                    'iops': 0,
+                    'device': '/dev/xvdf',
+                    'mount': '/volr'
+                }
+            ])
+
+            self.log.info('Configured the hudl_ebs.volumes attribute')
+
+            self.chef_node.save()
+            self.log.info('Saved the Chef Node configuration')


### PR DESCRIPTION
This adds support for automating the spin up of MongoDB Config Nodes. These nodes
- have data and journal volumes which are `5 GB`
- do not have a replica set
