### PR TITLE
IAM Policy for the Stage Updater Script

### DIFF
--- a/tyr/policies/__init__.py
+++ b/tyr/policies/__init__.py
@@ -4,5 +4,6 @@ import s3
 policies = {
     'allow-volume-control': ec2.allow_volume_control,
     'allow-upload-to-s3-fulla': s3.allow_upload_to_s3_fulla,
-    'allow-download-scripts-s3-fulla': s3.allow_download_scripts_s3_fulla
+    'allow-download-scripts-s3-fulla': s3.allow_download_scripts_s3_fulla,
+    'allow-download-script-s3-stage-updater': s3.allow_download_script_s3_stage_updater
 }

--- a/tyr/policies/s3.py
+++ b/tyr/policies/s3.py
@@ -53,7 +53,7 @@ allow_download_script_s3_stage_updater = """{
                 "s3:ListBucket"
             ],
             "Resource": [
-                "arn:aws:s3:::hudl-config/*"
+                "arn:aws:s3:::hudl-config/s-mongo/*"
             ]
         },
         {
@@ -63,7 +63,7 @@ allow_download_script_s3_stage_updater = """{
                 "s3:GetObject"
             ],
             "Resource": [
-                "arn:aws:s3:::hudl-config/*"
+                "arn:aws:s3:::hudl-config/s-mongo/*"
             ]
         }
     ]

--- a/tyr/policies/s3.py
+++ b/tyr/policies/s3.py
@@ -42,3 +42,29 @@ allow_download_scripts_s3_fulla = """{
         }
     ]
 }"""
+
+allow_download_script_s3_stage_updater = """{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "Stmt1408567829000",
+            "Effect": "Allow",
+            "Action": [
+                "s3:ListBucket"
+            ],
+            "Resource": [
+                "arn:aws:s3:::hudl-config/*"
+            ]
+        },
+        {
+            "Sid": "Stmt1408567479000",
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetObject"
+            ],
+            "Resource": [
+                "arn:aws:s3:::hudl-config/*"
+            ]
+        }
+    ]
+}"""

--- a/tyr/servers/mongo/data.py
+++ b/tyr/servers/mongo/data.py
@@ -32,6 +32,10 @@ class MongoDataNode(MongoReplicaSetMember):
 
         super(MongoDataNode, self).configure()
 
+        if self.environment == 'stage':
+            self.IAM_ROLE_POLICIES.append('allow-download-script-s3-stage-updater')
+            self.resolve_iam_role()
+
         if self.data_volume_size is None:
             self.log.warn('No data volume size provided')
             self.data_volume_size = 400


### PR DESCRIPTION
The [stage updater script](https://github.com/hudl/role_mongo/pull/20) is now downloaded from S3 instead of bundling it into the [role_mongo](https://github.com/hudl/role_mongo) repository.

This adds the `allow-download-script-s3-stage-updater` policy to stage MongoDB data nodes, allowing them to download the script.