### PR TITLE
Confirm the Status of MongoDB Before Starting It

### DIFF
--- a/tyr/utilities/replace_mongo_server.py
+++ b/tyr/utilities/replace_mongo_server.py
@@ -110,9 +110,21 @@ class ReplicaSet(object):
         log.debug('Re-determining the replica set primary')
         self.determine_primary(self.primary)
 
-        log.debug('Starting the mongo service on {address}'.format(
+        log.debug('Checking if mongod is running on {address}'.format(
                                                         address = address))
-        run_command(address, 'sudo service mongod start')
+
+        output = run_command(address, 'pgrep mongod')
+
+        if len(output) == 0:
+            log.debug('mongod is not running on {address}'.format(
+                                                        address = address))
+            log.debug('Starting the mongo service on {address}'.format(
+                                                        address = address))
+            run_command(address, 'sudo service mongod start')
+
+        else:
+            log.debug('mongod is already running on {address}'.format(
+                                                        address = address))
 
         log.debug('Adding {address} to the replica set'.format(address=address))
 


### PR DESCRIPTION
If `mongod` is already running and `sudo service mongod start` is executed, the PID for `mongod` is updated, but the new value isn't written to `/var/run/mongod/mongod.pid`. 

This leaves the server in an awkward state where:

- `service mongod status` returns `mongod dead but pid file exists`
- `sudo service mongod stop` fails
- `mongod` is actually running the whole time

Instead of ensuring that `mongod` is running on a node before adding it to the replica set by always running `sudo service mongod start`, `pgrep` will be used to confirm that `mongod` is not running before starting it.