### PR TITLE
Fix IAM Policy Comparisons

### DIFF
--- a/tyr/servers/server.py
+++ b/tyr/servers/server.py
@@ -5,6 +5,8 @@ import logging
 import os.path
 import chef
 import time
+import json
+import urllib
 from paramiko.client import AutoAddPolicy, SSHClient
 from tyr.policies import policies
 
@@ -461,8 +463,16 @@ named {name}""".format(path = d['path'], name = d['name']))
                 self.log.info('Policy "{policy}" already exists'.format(
                                         policy = policy))
 
-                if policies[policy] == self.iam.get_role_policy(self.role, policy):
+                tyr_copy = json.loads(policies[policy])
 
+                aws_copy = self.iam.get_role_policy(self.role, policy)
+                aws_copy = aws_copy['get_role_policy_response']
+                aws_copy = aws_copy['get_role_policy_result']
+                aws_copy = aws_copy['policy_document']
+                aws_copy = urllib.unquote(aws_copy)
+                aws_copy = json.loads(aws_copy)
+
+                if tyr_copy == aws_copy:
                     self.log.info('Policy "{policy}" is accurate'.format(
                                         policy = policy))
 


### PR DESCRIPTION
See #18 

> When `Tyr` checks for existing IAM policies on a role, it can detect policies that already exist, but it determines that they are not up to date and replaces them 100% of the time.

> I believe this is because the spacing and formatting in the policy when it's returned from AWS isn't consistent with what's used when the policy is defined in `Tyr`. So, when they're compared as strings, they're not equivalent.

> Proposed solution: Use the `json` module to load them both in as JSON objects and compare those.