### PR TITLE
Couchbase Automation

### DIFF
--- a/tyr/servers/cache/__init__.py
+++ b/tyr/servers/cache/__init__.py
@@ -1,0 +1,1 @@
+from server import CacheServer

--- a/tyr/servers/cache/server.py
+++ b/tyr/servers/cache/server.py
@@ -19,4 +19,21 @@ class CacheServer(Server):
                                             security_groups, block_devices,
                                             chef_path)
 
+    def configure(self):
+
+        super(CacheServer, self).configure()
+
+        # This is just a temporary fix to override the default security
+        # groups for Cache servers until the security_groups argument is
+        # removed.
+
+        self.security_groups = [
+            'management',
+            'chef-nodes',
+            self.envcl,
+            '{env}-cache-management'.format(env=self.environment[0])
+        ]
+
+        self.resolve_security_groups()
+
 

--- a/tyr/servers/cache/server.py
+++ b/tyr/servers/cache/server.py
@@ -9,9 +9,14 @@ class CacheServer(Server):
     def __init__(self, group=None, server_type=None, instance_type=None,
                     environment=None, ami=None, region=None, role=None,
                     keypair=None, availability_zone=None, security_groups=None,
-                    block_devices=None, chef_path=None):
+                    block_devices=None, chef_path=None, couchbase_version=None,
+                    couchbase_username=None, couchbase_password=None):
 
         if server_type is None: server_type = self.SERVER_TYPE
+
+        self.couchbase_version = couchbase_version
+        self.couchbase_username = couchbase_username
+        self.couchbase_password = couchbase_password
 
         super(CacheServer, self).__init__(group, server_type, instance_type,
                                             environment, ami, region, role,
@@ -35,4 +40,38 @@ class CacheServer(Server):
         ]
 
         self.resolve_security_groups()
+
+    def bake(self):
+
+        super(CacheServer, self).bake()
+
+        if not any([self.couchbase_version, self.couchbase_username,
+                        self.couchbase_password]):
+            return
+
+        with self.chef_api:
+
+            if self.couchbase_version:
+                self.chef_node.attributes.set_dotted('couchbase.server.version',
+                                                        self.couchbase_version)
+
+                self.log.info('Set the couchbase.server.version to' \
+                            '{version}'.format(version=self.couchbase_version))
+
+            if self.couchbase_username:
+                self.chef_node.attributes.set_dotted('couchbase.server.username',
+                                                        self.couchbase_username)
+
+                self.log.info('Set the couchbase.server.username to' \
+                            '{username}'.format(username=self.couchbase_username))
+
+            if self.couchbase_password:
+                self.chef_node.attributes.set_dotted('couchbase.server.password',
+                                                        self.couchbase_password)
+
+                self.log.info('Set the couchbase.server.password to' \
+                            '{password}'.format(password=self.couchbase_password))
+
+            self.chef_node.save()
+            self.log.info('Saved the Chef Node configuration')
 

--- a/tyr/servers/cache/server.py
+++ b/tyr/servers/cache/server.py
@@ -132,11 +132,13 @@ class CacheServer(Server):
 
             if r.status_code == 202:
 
-                self.log.info('Created memcached bucket hudl')
+                self.log.info('Created memcached bucket {bucket}'.format(
+                                                    bucket = self.bucket_name))
 
             else:
 
-                self.log.error('Failed to create memcached bucket hudl')
+                self.log.error('Failed to create memcached bucket {bucket}'.format(
+                                                    bucket = self.bucket_name))
                 self.log.error('Recieved status code {code} for Couchbase'.format(
                                                         code = r.status_code))
                 self.log.error('Recieved response {response}'.format(

--- a/tyr/servers/cache/server.py
+++ b/tyr/servers/cache/server.py
@@ -33,8 +33,10 @@ class CacheServer(Server):
 
         if self.environment == 'prod':
             self.instance_type = 'r3.large'
+            self.bucket = 'hudl'
         else:
             self.instance_type = 'm3.large'
+            self.bucket = 'hudl-stage'
 
         # This is just a temporary fix to override the default security
         # groups for Cache servers until the security_groups argument is
@@ -103,15 +105,10 @@ class CacheServer(Server):
                                                 hostname = self.hostname,
                                                 port = port)
 
-            if self.environment == 'prod':
-                bucket = 'hudl'
-            else:
-                bucket = 'hudl-stage'
-
             payload = {
                 'authType': 'sasl',
                 'bucketType': 'memcached',
-                'name': bucket,
+                'name': self.bucket,
                 'ramQuotaMB': memory_quota
             }
 

--- a/tyr/servers/cache/server.py
+++ b/tyr/servers/cache/server.py
@@ -28,6 +28,11 @@ class CacheServer(Server):
 
         super(CacheServer, self).configure()
 
+        if self.environment == 'prod':
+            self.instance_type = 'r3.large'
+        else:
+            self.instance_type = 'm3.large'
+
         # This is just a temporary fix to override the default security
         # groups for Cache servers until the security_groups argument is
         # removed.

--- a/tyr/servers/cache/server.py
+++ b/tyr/servers/cache/server.py
@@ -103,10 +103,15 @@ class CacheServer(Server):
                                                 hostname = self.hostname,
                                                 port = port)
 
+            if self.environment == 'prod':
+                bucket = 'hudl'
+            else:
+                bucket = 'hudl-stage'
+
             payload = {
                 'authType': 'sasl',
                 'bucketType': 'memcached',
-                'name': 'hudl',
+                'name': bucket,
                 'ramQuotaMB': memory_quota
             }
 

--- a/tyr/servers/cache/server.py
+++ b/tyr/servers/cache/server.py
@@ -36,4 +36,18 @@ class CacheServer(Server):
 
         self.resolve_security_groups()
 
+    def bake(self):
 
+        super(CacheServer, self).bake()
+
+        with self.chef_api:
+
+            if self.chef_node.chef_environment == 'prod':
+                self.chef_node.run_list.append('role[RoleSumoLogic]')
+
+            self.log.info('Set the run list to "{runlist}"'.format(
+                                            runlist = self.chef_node.run_list))
+
+            self.chef_node.save()
+
+            self.log.info('Saved the Chef Node configuration')

--- a/tyr/servers/cache/server.py
+++ b/tyr/servers/cache/server.py
@@ -126,3 +126,9 @@ class CacheServer(Server):
                 self.log.error('Recieved response {response}'.format(
                                                         response = r.json()))
 
+    def autorun(self):
+
+        super(CacheServer, self).autorun()
+        if self.baked():
+            self.configure_couchbase()
+

--- a/tyr/servers/cache/server.py
+++ b/tyr/servers/cache/server.py
@@ -13,13 +13,15 @@ class CacheServer(Server):
                     environment=None, ami=None, region=None, role=None,
                     keypair=None, availability_zone=None, security_groups=None,
                     block_devices=None, chef_path=None, couchbase_version=None,
-                    couchbase_username=None, couchbase_password=None):
+                    couchbase_username=None, couchbase_password=None,
+                    bucket_name=None):
 
         if server_type is None: server_type = self.SERVER_TYPE
 
         self.couchbase_version = couchbase_version
         self.couchbase_username = couchbase_username
         self.couchbase_password = couchbase_password
+        self.bucket_name = bucket_name
 
         super(CacheServer, self).__init__(group, server_type, instance_type,
                                             environment, ami, region, role,
@@ -33,10 +35,14 @@ class CacheServer(Server):
 
         if self.environment == 'prod':
             self.instance_type = 'r3.large'
-            self.bucket = 'hudl'
         else:
             self.instance_type = 'm3.large'
-            self.bucket = 'hudl-stage'
+
+        if not self.bucket_name:
+            if self.environment == 'prod':
+                self.bucket_name = 'hudl'
+            else:
+                self.bucket_name = 'hudl-stage'
 
         # This is just a temporary fix to override the default security
         # groups for Cache servers until the security_groups argument is
@@ -108,7 +114,7 @@ class CacheServer(Server):
             payload = {
                 'authType': 'sasl',
                 'bucketType': 'memcached',
-                'name': self.bucket,
+                'name': self.bucket_name,
                 'ramQuotaMB': memory_quota
             }
 

--- a/tyr/servers/cache/server.py
+++ b/tyr/servers/cache/server.py
@@ -36,18 +36,3 @@ class CacheServer(Server):
 
         self.resolve_security_groups()
 
-    def bake(self):
-
-        super(CacheServer, self).bake()
-
-        with self.chef_api:
-
-            if self.chef_node.chef_environment == 'prod':
-                self.chef_node.run_list.append('role[RoleSumoLogic]')
-
-            self.log.info('Set the run list to "{runlist}"'.format(
-                                            runlist = self.chef_node.run_list))
-
-            self.chef_node.save()
-
-            self.log.info('Saved the Chef Node configuration')

--- a/tyr/servers/cache/server.py
+++ b/tyr/servers/cache/server.py
@@ -1,0 +1,22 @@
+from tyr.servers.server import Server
+
+class CacheServer(Server):
+
+    SERVER_TYPE = 'cache'
+
+    CHEF_RUNLIST=['role[RoleCache]']
+
+    def __init__(self, group=None, server_type=None, instance_type=None,
+                    environment=None, ami=None, region=None, role=None,
+                    keypair=None, availability_zone=None, security_groups=None,
+                    block_devices=None, chef_path=None):
+
+        if server_type is None: server_type = self.SERVER_TYPE
+
+        super(CacheServer, self).__init__(group, server_type, instance_type,
+                                            environment, ami, region, role,
+                                            keypair, availability_zone,
+                                            security_groups, block_devices,
+                                            chef_path)
+
+

--- a/tyr/servers/cache/server.py
+++ b/tyr/servers/cache/server.py
@@ -117,7 +117,15 @@ class CacheServer(Server):
 
             auth = (username, password)
 
-            r = requests.post(uri, auth=auth, data=payload)
+            while True:
+                try:
+                    r = requests.post(uri, auth=auth, data=payload)
+                    break
+                except requests.exceptions.ConnectionError:
+                    self.log.error('Failed to connect to Couchbase')
+                    self.log.debug('Re-trying in 10 seconds')
+
+                    time.sleep(10)
 
             if r.status_code == 202:
 

--- a/tyr/servers/mongo/node.py
+++ b/tyr/servers/mongo/node.py
@@ -77,12 +77,6 @@ class MongoNode(Server):
             self.log.info('Set the MongoDB package version to {version}'.format(
                                                 version = self.mongodb_version))
 
-            if self.chef_node.chef_environment == 'prod':
-                self.chef_node.run_list.append('role[RoleSumoLogic]')
-
-            self.log.info('Set the run list to "{runlist}"'.format(
-                                        runlist = self.chef_node.run_list))
-
             self.chef_node.attributes.set_dotted('mongodb.node_type', self.CHEF_MONGODB_TYPE)
             self.log.info('Set the MongoDB node type to "{type_}"'.format(
                                             type_ = self.CHEF_MONGODB_TYPE))

--- a/tyr/servers/server.py
+++ b/tyr/servers/server.py
@@ -701,6 +701,9 @@ named {name}""".format(path = d['path'], name = d['name']))
 
             self.chef_node.run_list = self.CHEF_RUNLIST
 
+            if self.chef_node.chef_environment == 'prod':
+                self.chef_node.run_list.append('role[RoleSumoLogic]')
+
             self.log.info('Set Chef run list to {list}'.format(
                                             list = self.chef_node.run_list))
 

--- a/tyr/servers/server.py
+++ b/tyr/servers/server.py
@@ -701,9 +701,6 @@ named {name}""".format(path = d['path'], name = d['name']))
 
             self.chef_node.run_list = self.CHEF_RUNLIST
 
-            if self.chef_node.chef_environment == 'prod':
-                self.chef_node.run_list.append('role[RoleSumoLogic]')
-
             self.log.info('Set Chef run list to {list}'.format(
                                             list = self.chef_node.run_list))
 


### PR DESCRIPTION
This adds Couchbase integration to `Tyr`. The following values are used

| Variable | Test/Stage Environment | Prod Environment |
|:----------:|:--------------------------------:|:-------------------------:|
| Chef Runlist | `role[RoleCache]` | `role[RoleCache], role[RoleSumoLogic]` |
| Instance Type | `m3.large` | `r3.large` |
| Bucket Name | `hudl-stage` | `hudl` |

The bucket name can be set to another value by passing in the argument `bucket_name`.

The `autorun()` function will actually create the bucket, allocating 100% of the cluster resources to it, after `chef-client` has finished running. This behavior differs from other server types, where `autorun()` finishes after setting the Chef attributes, and doesn't monitor `chef-client` or perform operations on the server.