### PR TITLE
INF-730 - add vpc support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,9 +5,9 @@ setup(
     version = '0.0.1',
     author = 'Mihir Singh (@citruspi)',
     author_email = 'mihir.singh@hudl.com',
-    include_package_data = True,
     packages = ['tyr'],
     zip_safe = False,
+    include_package_data = True,
     platforms = 'any',
     install_requires = [
         'boto',

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,6 @@ setup(
     author_email = 'mihir.singh@hudl.com',
     packages = ['tyr'],
     zip_safe = False,
-    include_package_date = True,
     platforms = 'any',
     install_requires = [
         'boto',

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ setup(
     version = '0.0.1',
     author = 'Mihir Singh (@citruspi)',
     author_email = 'mihir.singh@hudl.com',
+    include_package_data = True,
     packages = ['tyr'],
     zip_safe = False,
     platforms = 'any',

--- a/tyr/servers/cache/server.py
+++ b/tyr/servers/cache/server.py
@@ -14,7 +14,7 @@ class CacheServer(Server):
                     keypair=None, availability_zone=None, security_groups=None,
                     block_devices=None, chef_path=None, couchbase_version=None,
                     couchbase_username=None, couchbase_password=None,
-                    bucket_name=None):
+                    bucket_name=None, subnet_id=None):
 
         if server_type is None: server_type = self.SERVER_TYPE
 
@@ -27,7 +27,7 @@ class CacheServer(Server):
                                             environment, ami, region, role,
                                             keypair, availability_zone,
                                             security_groups, block_devices,
-                                            chef_path)
+                                            chef_path, subnet_id)
 
     def configure(self):
 

--- a/tyr/servers/exceptions.py
+++ b/tyr/servers/exceptions.py
@@ -21,3 +21,9 @@ class NoSubnetReturned(Exception):
 
 class NoVPCReturned(Exception):
 	pass
+
+class NoSecurityGroupsReturned(Exception):
+	pass
+
+class MultipleSecurityGroupsReturned(Exception):
+	pass

--- a/tyr/servers/exceptions.py
+++ b/tyr/servers/exceptions.py
@@ -15,3 +15,9 @@ class InvalidAMI(Exception):
 
 class InvalidAvailabilityZone(Exception):
     pass
+
+class NoSubnetReturned(Exception):
+	pass
+
+class NoVPCReturned(Exception):
+	pass

--- a/tyr/servers/mongo/arbiter.py
+++ b/tyr/servers/mongo/arbiter.py
@@ -14,14 +14,14 @@ class MongoArbiterNode(MongoReplicaSetMember):
                     keypair = None, availability_zone = None,
                     security_groups = None, block_devices = None,
                     chef_path = None, replica_set = None,
-                    mongodb_version = None, vpc_id = None, subnet_id = None):
+                    mongodb_version = None, subnet_id = None):
 
         super(MongoArbiterNode, self).__init__(group, server_type, instance_type,
                                                 environment, ami, region, role,
                                                 keypair, availability_zone,
                                                 security_groups, block_devices,
                                                 chef_path, replica_set,
-                                                mongodb_version)
+                                                mongodb_version, subnet_id)
 
     def bake(self):
 

--- a/tyr/servers/mongo/arbiter.py
+++ b/tyr/servers/mongo/arbiter.py
@@ -14,7 +14,7 @@ class MongoArbiterNode(MongoReplicaSetMember):
                     keypair = None, availability_zone = None,
                     security_groups = None, block_devices = None,
                     chef_path = None, replica_set = None,
-                    mongodb_version = None):
+                    mongodb_version = None, vpc_id = None, subnet_id = None):
 
         super(MongoArbiterNode, self).__init__(group, server_type, instance_type,
                                                 environment, ami, region, role,

--- a/tyr/servers/mongo/config.py
+++ b/tyr/servers/mongo/config.py
@@ -13,14 +13,14 @@ class MongoConfigNode(MongoNode):
                     environment = None, ami = None, region = None, role = None,
                     keypair = None, availability_zone = None,
                     security_groups = None, block_devices = None,
-                    chef_path = None, vpc_id = None, subnet_id = None):
+                    chef_path = None, subnet_id = None):
 
         super(MongoConfigNode, self).__init__(group, server_type, instance_type,
                                                 environment, ami, region, role,
                                                 keypair, availability_zone,
                                                 security_groups,
                                                 block_devices, chef_path, 
-                                                vpc_id, subnet_id)
+                                                subnet_id)
 
     def bake(self):
 

--- a/tyr/servers/mongo/config.py
+++ b/tyr/servers/mongo/config.py
@@ -13,13 +13,14 @@ class MongoConfigNode(MongoNode):
                     environment = None, ami = None, region = None, role = None,
                     keypair = None, availability_zone = None,
                     security_groups = None, block_devices = None,
-                    chef_path = None):
+                    chef_path = None, vpc_id = None, subnet_id = None):
 
         super(MongoConfigNode, self).__init__(group, server_type, instance_type,
                                                 environment, ami, region, role,
                                                 keypair, availability_zone,
                                                 security_groups,
-                                                block_devices, chef_path)
+                                                block_devices, chef_path, 
+                                                vpc_id, subnet_id)
 
     def bake(self):
 

--- a/tyr/servers/mongo/data.py
+++ b/tyr/servers/mongo/data.py
@@ -16,14 +16,14 @@ class MongoDataNode(MongoReplicaSetMember):
                     security_groups = None, block_devices = None,
                     chef_path = None, replica_set = None,
                     data_volume_size = None, data_volume_iops = None,
-                    mongodb_version = None, vpc_id = None, subnet_id = None):
+                    mongodb_version = None, subnet_id = None):
 
         super(MongoDataNode, self).__init__(group, server_type, instance_type,
                                             environment, ami, region, role,
                                             keypair, availability_zone,
                                             security_groups, block_devices,
                                             chef_path, replica_set,
-                                            mongodb_version, vpc_id, subnet_id)
+                                            mongodb_version, subnet_id)
 
         self.data_volume_size = data_volume_size
         self.data_volume_iops = data_volume_iops

--- a/tyr/servers/mongo/data.py
+++ b/tyr/servers/mongo/data.py
@@ -16,14 +16,14 @@ class MongoDataNode(MongoReplicaSetMember):
                     security_groups = None, block_devices = None,
                     chef_path = None, replica_set = None,
                     data_volume_size = None, data_volume_iops = None,
-                    mongodb_version = None):
+                    mongodb_version = None, vpc_id = None, subnet_id = None):
 
         super(MongoDataNode, self).__init__(group, server_type, instance_type,
                                             environment, ami, region, role,
                                             keypair, availability_zone,
                                             security_groups, block_devices,
                                             chef_path, replica_set,
-                                            mongodb_version)
+                                            mongodb_version, vpc_id, subnet_id)
 
         self.data_volume_size = data_volume_size
         self.data_volume_iops = data_volume_iops

--- a/tyr/servers/mongo/data_warehousing.py
+++ b/tyr/servers/mongo/data_warehousing.py
@@ -20,7 +20,8 @@ class MongoDataWarehousingNode(MongoReplicaSetMember):
                     keypair = None, availability_zone = None,
                     security_groups = None, block_devices = None,
                     chef_path = None, replica_set = None,
-                    data_volume_size = None, mongodb_version = None):
+                    data_volume_size = None, mongodb_version = None,
+                    vpc_id = None, subnet_id = None):
 
         super(MongoDataWarehousingNode, self).__init__(group, server_type,
                                                         instance_type,
@@ -31,7 +32,9 @@ class MongoDataWarehousingNode(MongoReplicaSetMember):
                                                         block_devices,
                                                         chef_path,
                                                         replica_set,
-                                                        mongodb_version)
+                                                        mongodb_version,
+                                                        vpc_id,
+                                                        subnet_id)
 
         self.data_volume_size = data_volume_size
 

--- a/tyr/servers/mongo/data_warehousing.py
+++ b/tyr/servers/mongo/data_warehousing.py
@@ -21,7 +21,7 @@ class MongoDataWarehousingNode(MongoReplicaSetMember):
                     security_groups = None, block_devices = None,
                     chef_path = None, replica_set = None,
                     data_volume_size = None, mongodb_version = None,
-                    vpc_id = None, subnet_id = None):
+                    subnet_id = None):
 
         super(MongoDataWarehousingNode, self).__init__(group, server_type,
                                                         instance_type,
@@ -33,7 +33,6 @@ class MongoDataWarehousingNode(MongoReplicaSetMember):
                                                         chef_path,
                                                         replica_set,
                                                         mongodb_version,
-                                                        vpc_id,
                                                         subnet_id)
 
         self.data_volume_size = data_volume_size

--- a/tyr/servers/mongo/member.py
+++ b/tyr/servers/mongo/member.py
@@ -9,7 +9,8 @@ class MongoReplicaSetMember(MongoNode):
                     keypair = None, availability_zone = None,
                     security_groups = None, block_devices = None,
                     chef_path = None, replica_set = None,
-                    mongodb_version = None):
+                    mongodb_version = None,
+                    vpc_id = None, subnet_id = None):
 
         super(MongoReplicaSetMember, self).__init__(group, server_type, instance_type,
                                                     environment, ami, region,
@@ -17,7 +18,9 @@ class MongoReplicaSetMember(MongoNode):
                                                     availability_zone,
                                                     security_groups,
                                                     block_devices, chef_path,
-                                                    mongodb_version)
+                                                    mongodb_version,
+                                                    vpc_id,
+                                                    subnet_id)
 
         self.replica_set = replica_set
 

--- a/tyr/servers/mongo/member.py
+++ b/tyr/servers/mongo/member.py
@@ -10,7 +10,7 @@ class MongoReplicaSetMember(MongoNode):
                     security_groups = None, block_devices = None,
                     chef_path = None, replica_set = None,
                     mongodb_version = None,
-                    vpc_id = None, subnet_id = None):
+                    subnet_id = None):
 
         super(MongoReplicaSetMember, self).__init__(group, server_type, instance_type,
                                                     environment, ami, region,
@@ -19,7 +19,6 @@ class MongoReplicaSetMember(MongoNode):
                                                     security_groups,
                                                     block_devices, chef_path,
                                                     mongodb_version,
-                                                    vpc_id,
                                                     subnet_id)
 
         self.replica_set = replica_set

--- a/tyr/servers/mongo/node.py
+++ b/tyr/servers/mongo/node.py
@@ -49,8 +49,6 @@ class MongoNode(Server):
         # groups for MongoDB nodes until the security_groups argument
         # is removed.
 
-
-
         self.resolve_security_groups()
 
     def run_mongo(self, command):

--- a/tyr/servers/mongo/node.py
+++ b/tyr/servers/mongo/node.py
@@ -37,12 +37,18 @@ class MongoNode(Server):
 
         self.log.info('Using version {version} of MongoDB'.format(
                                                 version = self.mongodb_version))
+
+        # This is just a temporary fix to override the default security
+        # groups for MongoDB nodes until the security_groups argument
+        # is removed.
+
         self.security_groups = [
             'management',
             'chef-nodes',
             self.envcl,
             '{env}-mongo-management'.format(env=self.environment[0])
         ]
+
         self.resolve_security_groups()
 
     def run_mongo(self, command):

--- a/tyr/servers/mongo/node.py
+++ b/tyr/servers/mongo/node.py
@@ -29,14 +29,14 @@ class MongoNode(Server):
 
     def configure(self):
 
-        super(MongoNode, self).configure()
-
         self.security_groups = [
             'management',
             'chef-nodes',
             self.envcl,
             '{env}-mongo-management'.format(env=self.environment[0])
         ]
+
+        super(MongoNode, self).configure()
 
         if self.mongodb_version is None:
             self.log.warn('MongoDB version not set')
@@ -45,11 +45,6 @@ class MongoNode(Server):
         self.log.info('Using version {version} of MongoDB'.format(
                                                 version = self.mongodb_version))
 
-        # This is just a temporary fix to override the default security
-        # groups for MongoDB nodes until the security_groups argument
-        # is removed.
-
-        self.resolve_security_groups()
 
     def run_mongo(self, command):
 

--- a/tyr/servers/mongo/node.py
+++ b/tyr/servers/mongo/node.py
@@ -29,13 +29,6 @@ class MongoNode(Server):
 
     def configure(self):
 
-        self.security_groups = [
-            'management',
-            'chef-nodes',
-            self.envcl,
-            '{env}-mongo-management'.format(env=self.environment[0])
-        ]
-
         super(MongoNode, self).configure()
 
         if self.mongodb_version is None:
@@ -44,7 +37,13 @@ class MongoNode(Server):
 
         self.log.info('Using version {version} of MongoDB'.format(
                                                 version = self.mongodb_version))
-
+        self.security_groups = [
+            'management',
+            'chef-nodes',
+            self.envcl,
+            '{env}-mongo-management'.format(env=self.environment[0])
+        ]
+        self.resolve_security_groups()
 
     def run_mongo(self, command):
 

--- a/tyr/servers/mongo/node.py
+++ b/tyr/servers/mongo/node.py
@@ -29,14 +29,14 @@ class MongoNode(Server):
 
     def configure(self):
 
+        super(MongoNode, self).configure()
+
         self.security_groups = [
             'management',
             'chef-nodes',
-            '{envcl}'.format(envcl=self.envcl),
+            self.envcl,
             '{env}-mongo-management'.format(env=self.environment[0])
         ]
-
-        super(MongoNode, self).configure()
 
         if self.mongodb_version is None:
             self.log.warn('MongoDB version not set')

--- a/tyr/servers/mongo/node.py
+++ b/tyr/servers/mongo/node.py
@@ -30,10 +30,10 @@ class MongoNode(Server):
     def configure(self):
 
         self.security_groups = [
-            'management-testvpc',
-            'chef-nodes-testvpc',
-            '{envcl}-testvpc'.format(envcl=self.envcl),
-            '{env}-mongo-management-testvpc'.format(env = self.environment[0])
+            'management',
+            'chef-nodes',
+            '{envcl}'.format(envcl=self.envcl),
+            '{env}-mongo-management'.format(env=self.environment[0])
         ]
 
         super(MongoNode, self).configure()

--- a/tyr/servers/mongo/node.py
+++ b/tyr/servers/mongo/node.py
@@ -14,7 +14,8 @@ class MongoNode(Server):
                     environment = None, ami = None, region = None, role = None,
                     keypair = None, availability_zone = None,
                     security_groups = None, block_devices = None,
-                    chef_path = None, mongodb_version=None):
+                    chef_path = None, mongodb_version=None,
+                    vpc_id = None, subnet_id = None):
 
         self.mongodb_version = mongodb_version
 
@@ -24,9 +25,16 @@ class MongoNode(Server):
                                         environment, ami, region, role,
                                         keypair, availability_zone,
                                         security_groups, block_devices,
-                                        chef_path)
+                                        chef_path, vpc_id, subnet_id)
 
     def configure(self):
+
+        self.security_groups = [
+            'management-testvpc',
+            'chef-nodes-testvpc',
+            '{envcl}-testvpc'.format(envcl=self.envcl),
+            '{env}-mongo-management-testvpc'.format(env = self.environment[0])
+        ]
 
         super(MongoNode, self).configure()
 
@@ -41,12 +49,7 @@ class MongoNode(Server):
         # groups for MongoDB nodes until the security_groups argument
         # is removed.
 
-        self.security_groups = [
-            'management',
-            'chef-nodes',
-            self.envcl,
-            '{env}-mongo-management'.format(env = self.environment[0])
-        ]
+
 
         self.resolve_security_groups()
 

--- a/tyr/servers/mongo/node.py
+++ b/tyr/servers/mongo/node.py
@@ -15,7 +15,7 @@ class MongoNode(Server):
                     keypair = None, availability_zone = None,
                     security_groups = None, block_devices = None,
                     chef_path = None, mongodb_version=None,
-                    vpc_id = None, subnet_id = None):
+                    subnet_id = None):
 
         self.mongodb_version = mongodb_version
 
@@ -25,7 +25,7 @@ class MongoNode(Server):
                                         environment, ami, region, role,
                                         keypair, availability_zone,
                                         security_groups, block_devices,
-                                        chef_path, vpc_id, subnet_id)
+                                        chef_path, subnet_id)
 
     def configure(self):
 

--- a/tyr/servers/nginx/server.py
+++ b/tyr/servers/nginx/server.py
@@ -21,14 +21,15 @@ class NginxServer(Server):
     def __init__(self, group=None, server_type=None, instance_type=None,
                     environment=None, ami=None, region=None, role=None,
                     keypair=None, availability_zone=None, security_groups=None,
-                    block_devices=None, chef_path=None):
+                    block_devices=None, chef_path=None, subnet_id=None):
 
         if server_type is None: server_type = self.SERVER_TYPE
 
         super(NginxServer, self).__init__(group, server_type, instance_type,
                                     environment, ami, region, role,
                                     keypair, availability_zone,
-                                    security_groups, chef_path)
+                                    security_groups, block_devices,
+                                    chef_path, subnet_id)
 
     def configure(self):
 

--- a/tyr/servers/server.py
+++ b/tyr/servers/server.py
@@ -604,26 +604,18 @@ named {name}""".format(path = d['path'], name = d['name']))
             raise e
 
     def get_security_group_ids(self, security_groups):
-            ec2Conn = self.ec2
-            security_group_ids = list()
+            security_group_ids = []
             for group in self.security_groups:
                 filters = {'group-name': group}
-                security_groups = ec2Conn.get_all_security_groups(
+                security_groups = self.ec2.get_all_security_groups(
                     filters=filters)
-
                 if len(security_groups) == 1:
-                    security_group_ids.append(
-                        security_groups[0].id)
-                elif len(security_groups) > 1:
-                    self.log.error(
-                        "Multiple security groups match {group}".format(
-                            group=group))
-                    exit(1)
+                    security_group_ids.append(security_groups[0].id)
+                elif len(security_groups) == 0:
+                    raise NoSecurityGroupsReturned("No VPC returned.")
                 else:
-                    self.log.error(
-                        "No security groups match {group}".format(
-                            group=group))
-                    exit(1)
+                    raise MultipleSecurityGroupsReturned(
+                        "More than 1 VPC returned")
 
             return security_group_ids
 

--- a/tyr/servers/server.py
+++ b/tyr/servers/server.py
@@ -387,28 +387,30 @@ named {name}""".format(path = d['path'], name = d['name']))
         return bdm
 
     def get_subnet_vpc_id(self, subnet_id):
-        vpcConn = VPCConnection()
-        subnets = vpcConn.get_all_subnets(
+        vpc_conn = VPCConnection()
+        subnets = vpc_conn.get_all_subnets(
             filters={'subnet_id': subnet_id})
         if len(subnets) == 1:
             vpc_id = subnets[0].vpc_id
             return vpc_id
+        elif len(subnets) == 0:
+            raise NoSubnetReturned("No subnets returned")
         else:
-            self.log.error("None or greater then 1 subnet returned")
-            exit(1)  # should probably throw an exception, if I knew how
+            raise Exception("More than 1 subnet returned")
 
     def get_vpc_suffix(self, vpc_id):
-            vpcConn = VPCConnection()
-            vpc = vpcConn.get_all_vpcs(filters={'vpc_id': vpc_id})
+            vpc_conn = VPCConnection()
+            vpc = vpc_conn.get_all_vpcs(filters={'vpc_id': vpc_id})
             if len(vpc) == 1:
                 vpc_suffix = vpc[0].tags['vpcSuffix']
                 if vpc_suffix is None:
                     return "vpc"
                 else:
                     return vpc_suffix
+            elif len(vpc) == 0:
+                raise NoVPCReturned("No VPC returned.")
             else:
-                self.log.error("None or greater then 1 vpc returned")
-                exit(1)  # should probably throw an exception, if I knew how
+                raise Exception("More than 1 VPC returned")
 
     def resolve_security_groups(self):
         # If the server is being spun up in a subnet, append a vpc suffix
@@ -430,8 +432,8 @@ named {name}""".format(path = d['path'], name = d['name']))
                 if self.subnet_id is None:
                     self.ec2.create_security_group(group, group)
                 else:
-                    vpcConn = VPCConnection()
-                    vpcConn.create_security_group(
+                    vpc_conn = VPCConnection()
+                    vpc_conn.create_security_group(
                         group, group, vpc_id=vpc_id)
                 self.log.info('Created security group {group}'.format(
                                 group=group))
@@ -569,14 +571,14 @@ named {name}""".format(path = d['path'], name = d['name']))
     def get_subnet_availability_zone(self, subnet_id):
         self.log.info(
             "getting zone for subnet {subnet_id}".format(subnet_id=subnet_id))
-        VpcConn = VPCConnection()
+        vpc_conn = VPCConnection()
         filters = {'subnet-id': subnet_id}
-        subnets = VpcConn.get_all_subnets(filters=filters)
+        subnets = vpc_conn.get_all_subnets(filters=filters)
 
         if len(subnets) == 1:
             availability_zone = subnets[0].availability_zone
 
-            log_message = 'subnet {subnet_id} is in ' \
+            log_message = 'Subnet {subnet_id} is in ' \
                           'availability zone {availability_zone}'
             self.log.info(log_message.format(
                             subnet_id=subnet_id,

--- a/tyr/servers/server.py
+++ b/tyr/servers/server.py
@@ -170,13 +170,13 @@ class Server(object):
 
         valid = lambda z: z in [zone.name for zone in self.ec2.get_all_zones()]
 
-       # if not valid(self.availability_zone):
-       #     error = '"{zone}" is not a valid EC2 availability zone'.format(
-       #             zone = self.availability_zone)
-       #     raise InvalidAvailabilityZone(error)
+        if not valid(self.availability_zone):
+            error = '"{zone}" is not a valid EC2 availability zone'.format(
+                    zone=self.availability_zone)
+            raise InvalidAvailabilityZone(error)
 
-       # self.log.info('Using EC2 Availability Zone "{zone}"'.format(
-       #                 zone = self.availability_zone))
+        self.log.info('Using EC2 Availability Zone "{zone}"'.format(
+                        zone=self.availability_zone))
 
         if self.security_groups is None:
             self.log.warn('No EC2 security groups provided')

--- a/tyr/servers/server.py
+++ b/tyr/servers/server.py
@@ -563,8 +563,10 @@ named {name}""".format(path = d['path'], name = d['name']))
 
         if len(subnets) == 1:
             availability_zone = subnets[0].availability_zone
-            self.log.info("""subnet {subnet_id} is in
-                 availability zone {availability_zone}""".format(
+
+            log_message = 'subnet {subnet_id} is in ' \
+                          'availability zone {availability_zone}'
+            self.log.info(log_message.format(
                             subnet_id=subnet_id,
                             availability_zone=availability_zone))
             return availability_zone

--- a/tyr/servers/server.py
+++ b/tyr/servers/server.py
@@ -160,7 +160,7 @@ class Server(object):
                 self.log.warn('No EC2 availability zone provided, using zone c')
                 self.availability_zone = 'c'
         else:
-            if self.availability_zone not is None:
+            if self.availability_zone is not None:
                 self.log.warn('Both availability zone and subnet set, '
                               'using availability zone from subnet')
             self.vpc_id = self.get_subnet_vpc_id(self.subnet_id)


### PR DESCRIPTION
Adds VPC support to Tyr.

In order to spin up a server in a VPC you must provide a subnet_id and exclude the availability zone.

When a subnet_id is supplied, tyr will now:
 - lookup the availability zone that the subnet is in
 - append a vpc suffix to the name of the security groups.  by default it will use -vpc.. you can override it for a VPC by setting the ```vpcSuffix``` tag on the VPC. for example: setting ```testvpc``` will append ```-testvpc``` to the end of the security groups.
      - this is to stop us from having security group name collisions.

- create a network adapter for the new server and apply security groups to the network adapter along with an ec2 generated public dns name

Also, You can't use security group names in VPCs, so this switches to resolve the security group id for both VPC and EC2-Classic. 

I also added *.pyc files to the .gitInore and fixed a few PEP 8 formatting issues and fixed a typo with setup.py where it was using ```include_package_date```  instead of ```include_package_data```