### PR TITLE
Fixed the Fulla Volume Ownership

### DIFF
--- a/tyr/servers/mongo/data_warehousing.py
+++ b/tyr/servers/mongo/data_warehousing.py
@@ -73,8 +73,8 @@ class MongoDataWarehousingNode(MongoReplicaSetMember):
                     'mount': '/volr'
                 },
                 {
-                    'user': 'mongod',
-                    'group': 'mongod',
+                    'user': 'ec2-user',
+                    'group': 'ec2-user',
                     'size': self.data_volume_size,
                     'iops': 0,
                     'device': '/dev/xvde',


### PR DESCRIPTION
Instead of running `chown -R ec2-user:ec2-user /fulla/` in the `role_mongo` cookbook, we can set the desired `user` and `group` values to be used with the `hudl-ebs` cookbook when the volume is mounted.

This fixes the permissions issue that the `fulla` script was running into.