### PR TITLE
Couchbase Server Replacement Automation

### DIFF
--- a/tyr/utilities/replace_couchbase_server.py
+++ b/tyr/utilities/replace_couchbase_server.py
@@ -27,3 +27,10 @@ if not log.handlers:
     ch.setFormatter(formatter)
     log.addHandler(ch)
 
+class Cluster(object):
+
+    def __init__(self, member, username='Administrator', password=None):
+        self.member = member
+        self.username = username
+        self.password = password
+

--- a/tyr/utilities/replace_couchbase_server.py
+++ b/tyr/utilities/replace_couchbase_server.py
@@ -263,3 +263,6 @@ def replace_couchbase_server(member, group=None, environment=None,
 
     while cluster.is_rebalancing:
         pass
+
+    log.info('{old} has been replaced with {new}.'.format(old=member,
+                                                            new=node.hostname))

--- a/tyr/utilities/replace_couchbase_server.py
+++ b/tyr/utilities/replace_couchbase_server.py
@@ -172,6 +172,10 @@ class Cluster(object):
 
     def remove_node(self, hostname):
 
+        log.warn('The removal of an active node from a cluster should be ' \
+                    'performed using rebalance() with the ejected_nodes ' \
+                    'argument')
+
         payload = {
                     'otpNode': 'ns_1@{hostname}'.format(hostname=hostname)
                   }

--- a/tyr/utilities/replace_couchbase_server.py
+++ b/tyr/utilities/replace_couchbase_server.py
@@ -1,0 +1,29 @@
+import time
+import logging
+
+def timeit(method):
+
+    def timed(*args, **kwargs):
+        start = time.time()
+        response = method(*args, **kwargs)
+        end = time.time()
+
+        log.debug('Executed {name} in {elapsed} seconds'.format(
+                                                        name = method.__name__,
+                                                        elapsed = end-start))
+
+        return response
+
+    return timed
+
+log = logging.getLogger('Tyr.Utilities.ReplaceCouchbaseServer')
+if not log.handlers:
+    log.setLevel(logging.DEBUG)
+    ch = logging.StreamHandler()
+    ch.setLevel(logging.DEBUG)
+    formatter = logging.Formatter(
+            '%(asctime)s [%(name)s] %(levelname)s: %(message)s',
+            datefmt='%H:%M:%S')
+    ch.setFormatter(formatter)
+    log.addHandler(ch)
+

--- a/tyr/utilities/replace_couchbase_server.py
+++ b/tyr/utilities/replace_couchbase_server.py
@@ -47,3 +47,21 @@ class Cluster(object):
         elif method == 'POST':
             return requests.post(uri, auth=auth, data=payload)
 
+    @property
+    def pool(self):
+
+        r = self.request('/pools/')
+
+        while r.status_code != 200:
+
+            log.error('Received {code} from the API'.format(code=r.status_code))
+            log.debug('Re-trying in 10 seconds')
+
+            time.sleep(10)
+
+            r = self.request('/pools/')
+
+        pools = r.json()['pools']
+
+        return pools[0]['name']
+

--- a/tyr/utilities/replace_couchbase_server.py
+++ b/tyr/utilities/replace_couchbase_server.py
@@ -200,7 +200,7 @@ def replace_couchbase_server(member, group=None, environment=None,
 
     cluster.add_node(node.hostname)
 
-    cluster.rebalance(known_nodes=cluster.nodes)
+    cluster.rebalance()
 
     while cluster.is_rebalancing:
         pass
@@ -210,9 +210,7 @@ def replace_couchbase_server(member, group=None, environment=None,
 
     cluster.member = node.hostname
 
-    cluster.remove_node(member)
-
-    cluster.rebalance(known_nodes=cluster.nodes, ejected_nodes=member)
+    cluster.rebalance(ejected_nodes=['ns_1@{member}'.format(member=member)])
 
     while cluster.is_rebalancing:
         pass

--- a/tyr/utilities/replace_couchbase_server.py
+++ b/tyr/utilities/replace_couchbase_server.py
@@ -85,3 +85,31 @@ class Cluster(object):
 
         return buckets[0]['name']
 
+    def rebalance(self, ejected_nodes=None, known_nodes=None):
+
+        if ejected_nodes:
+            ejected_nodes = ','.join(ejected_nodes)
+        else:
+            ejected_nodes = ''
+
+        if known_nodes:
+            known_nodes = ','.join(known_nodes)
+        else:
+            known_nodes = ''
+
+        data = {
+                'ejectedNodes': ejected_nodes,
+                'knownNodes': known_nodes
+        }
+
+        r = self.request('/controller/rebalance', method='POST', payload=data)
+
+        while r.status_code != 200:
+
+            log.error('Received {code} from the API'.format(code=r.status_code))
+            log.debug('Re-trying in 10 seconds')
+
+            time.sleep(10)
+
+            r = self.request('/controller/rebalance', method='POST',
+                                payload=data)

--- a/tyr/utilities/replace_couchbase_server.py
+++ b/tyr/utilities/replace_couchbase_server.py
@@ -163,8 +163,8 @@ class Cluster(object):
                     'password': self.password
                   }
 
-        r = self.request('/controller/addNode/', method='POST', payload=payload,
-                            success=lambda r: r.status_code >= 400)[0]
+        r = self.request('/controller/addNode/', method='POST',
+                            payload=payload)[0]
 
         log.info('{hostname} successfully added as {otpNode}'.format(
                                                 hostname = hostname,

--- a/tyr/utilities/replace_couchbase_server.py
+++ b/tyr/utilities/replace_couchbase_server.py
@@ -190,10 +190,9 @@ def replace_couchbase_server(member, group=None, environment=None,
 
     public_address = member
 
+    conn = boto.ec2.connect_to_region('us-east-1')
+
     if member.split('.')[0] == '10':
-
-        conn = boto.ec2.connect_to_region('us-east-1')
-
         reservations = conn.get_all_instances(filters={
                                                     'private-ip-address': member
                                                        })
@@ -201,6 +200,13 @@ def replace_couchbase_server(member, group=None, environment=None,
         instance = reservations[0].instances[0]
 
         public_address = instance.public_dns_name
+
+    else:
+        reservations = conn.get_all_instances(filters={
+                                                'tag:Name': member.split('.')[0]
+                                                      })
+
+        instance = reservations[0].instances[0]
 
     cluster = Cluster(public_address, username=couchbase_username,
                         password=couchbase_password)

--- a/tyr/utilities/replace_couchbase_server.py
+++ b/tyr/utilities/replace_couchbase_server.py
@@ -65,3 +65,23 @@ class Cluster(object):
 
         return pools[0]['name']
 
+    @property
+    def bucket(self):
+
+        path = '/pools/{pool}/buckets/'.format(pool = self.pool)
+
+        r = self.request(path)
+
+        while r.status_code != 200:
+
+            log.error('Received {code} from the API'.format(code=r.status_code))
+            log.debug('Re-trying in 10 seconds')
+
+            time.sleep(10)
+
+            r = self.request(path)
+
+        buckets = r.json()
+
+        return buckets[0]['name']
+

--- a/tyr/utilities/replace_couchbase_server.py
+++ b/tyr/utilities/replace_couchbase_server.py
@@ -152,3 +152,27 @@ class Cluster(object):
 
         return [node['otpNode'] for node in response['nodes']]
 
+    def add_node(self, hostname):
+
+        payload = {
+                    'hostname': hostname,
+                    'user': self.username,
+                    'password': self.password
+                  }
+
+        r = self.request('/controller/addNode/', method='POST', payload=payload)
+
+        if r.status_code > 400:
+
+            log.error('Received {code} from the API'.format(code=r.status_code))
+            log.debug('Re-trying in 10 seconds')
+
+            time.sleep(10)
+
+            r = self.request('/controller/addNode/', method='POST',
+                                payload=payload)
+
+        log.info('{hostname} successfully added as {otpNode}'.format(
+                                                hostname = hostname,
+                                                otpNode = r.json()['otpNode']))
+

--- a/tyr/utilities/replace_couchbase_server.py
+++ b/tyr/utilities/replace_couchbase_server.py
@@ -39,6 +39,7 @@ class Cluster(object):
         self.username = username
         self.password = password
 
+    @timeit
     def request(self, path, method='GET', payload=None,
                 success=lambda r: r.status_code == 200, retry=True):
 
@@ -74,6 +75,7 @@ class Cluster(object):
         return (r, success(r))
 
     @property
+    @timeit
     def pool(self):
 
         r = self.request('/pools/')[0]
@@ -83,6 +85,7 @@ class Cluster(object):
         return pools[0]['name']
 
     @property
+    @timeit
     def bucket(self):
 
         path = '/pools/{pool}/buckets/'.format(pool = self.pool)
@@ -93,6 +96,7 @@ class Cluster(object):
 
         return buckets[0]['name']
 
+    @timeit
     def rebalance(self, ejected_nodes=None, known_nodes=None):
 
         if ejected_nodes:
@@ -113,6 +117,7 @@ class Cluster(object):
         r = self.request('/controller/rebalance', method='POST', payload=data)
 
     @property
+    @timeit
     def is_rebalancing(self):
 
         r = self.request('/pools/{pool}/rebalanceProgress/'.format(
@@ -123,6 +128,7 @@ class Cluster(object):
         return (progress['status'] == 'running')
 
     @property
+    @timeit
     def nodes(self):
 
         r = self.request('/pools/nodes/')[0]
@@ -157,6 +163,7 @@ class Cluster(object):
                         }
                       }
 
+    @timeit
     def add_node(self, hostname):
 
         payload = {
@@ -172,6 +179,7 @@ class Cluster(object):
                                                 hostname = hostname,
                                                 otpNode = r.json()['otpNode']))
 
+    @timeit
     def remove_node(self, hostname):
 
         log.warn('The removal of an active node from a cluster should be ' \
@@ -185,6 +193,7 @@ class Cluster(object):
         r = self.request('/controller/ejectNode/', method='POST',
                             payload=payload)
 
+@timeit
 def replace_couchbase_server(member, group=None, environment=None,
                                 availability_zone=None, couchbase_username=None,
                                 couchbase_password=None, replace=True,

--- a/tyr/utilities/replace_couchbase_server.py
+++ b/tyr/utilities/replace_couchbase_server.py
@@ -101,7 +101,7 @@ class Cluster(object):
         if known_nodes:
             known_nodes = ','.join(known_nodes)
         else:
-            known_nodes = ''
+            known_nodes = ','.join([node['otpNode'] for node in  self.nodes])
 
         data = {
                 'ejectedNodes': ejected_nodes,

--- a/tyr/utilities/replace_couchbase_server.py
+++ b/tyr/utilities/replace_couchbase_server.py
@@ -34,3 +34,16 @@ class Cluster(object):
         self.username = username
         self.password = password
 
+    def request(self, path, method='GET', payload=None):
+
+        uri = 'http://{hostname}:8091{path}'.format(hostname = self.member,
+                                                        path = path)
+
+        auth = (self.username, self.password)
+
+        if method == 'GET':
+            return requests.get(uri, auth=auth)
+
+        elif method == 'POST':
+            return requests.post(uri, auth=auth, data=payload)
+

--- a/tyr/utilities/replace_couchbase_server.py
+++ b/tyr/utilities/replace_couchbase_server.py
@@ -188,7 +188,21 @@ def replace_couchbase_server(member, group=None, environment=None,
                                 couchbase_password=None, replace=True,
                                 reroute=True, terminate=False):
 
-    cluster = Cluster(member, username=couchbase_username,
+    public_address = member
+
+    if member.split('.')[0] == '10':
+
+        conn = boto.ec2.connect_to_region('us-east-1')
+
+        reservations = conn.get_all_instances(filters={
+                                                    'private-ip-address': member
+                                                       })
+
+        instance = reservations[0].instances[0]
+
+        public_address = instance.public_dns_name
+
+    cluster = Cluster(public_address, username=couchbase_username,
                         password=couchbase_password)
 
     node = CacheServer(group=group, environment=environment,

--- a/tyr/utilities/replace_couchbase_server.py
+++ b/tyr/utilities/replace_couchbase_server.py
@@ -133,3 +133,22 @@ class Cluster(object):
         progress = r.json()
 
         return (progress['status'] == 'running')
+
+    @property
+    def nodes(self):
+
+        r = self.request('/pools/{pool}/nodes/'.format(pool=self.pool))
+
+        while r.status_code != 200:
+
+            log.error('Received {code} from the API'.format(code=r.status_code))
+            log.debug('Re-trying in 10 seconds')
+
+            time.sleep(10)
+
+            r = self.request('/pools/{pool}/nodes/'.format(pool=self.pool))
+
+        response = r.json()
+
+        return [node['otpNode'] for node in response['nodes']]
+

--- a/tyr/utilities/replace_couchbase_server.py
+++ b/tyr/utilities/replace_couchbase_server.py
@@ -176,3 +176,25 @@ class Cluster(object):
                                                 hostname = hostname,
                                                 otpNode = r.json()['otpNode']))
 
+    def remove_node(self, hostname):
+
+        payload = {
+                    'otpNode': 'ns_1@{hostname}'.format(hostname=hostname)
+                  }
+
+        r = self.request('/controller/ejectNode/', method='POST',
+                            payload=payload)
+
+        while r.status_code > 400:
+
+            log.error('Received {code} from the API'.format(code=r.status_code))
+            log.debug('Re-trying in 10 seconds')
+
+            time.sleep(10)
+
+            r = self.request('/controller/ejectNode/', method='POST',
+                             payload=payload)
+
+            log.info('{hostname} successfully removed'.format(
+                                                hostname = hostname))
+

--- a/tyr/utilities/replace_couchbase_server.py
+++ b/tyr/utilities/replace_couchbase_server.py
@@ -113,3 +113,23 @@ class Cluster(object):
 
             r = self.request('/controller/rebalance', method='POST',
                                 payload=data)
+
+    @property
+    def is_rebalancing(self):
+
+        r = self.request('/pools/{pool}/rebalanceProgress/'.format(
+                                                            pool = self.pool))
+
+        while r.status_code != 200:
+
+            log.error('Received {code} from the API'.format(code=r.status_code))
+            log.debug('Re-trying in 10 seconds')
+
+            time.sleep(10)
+
+            r = self.request('/pools/{pool}/rebalanceProgress/'.format(
+                                                            pool = self.pool))
+
+        progress = r.json()
+
+        return (progress['status'] == 'running')

--- a/tyr/utilities/replace_couchbase_server.py
+++ b/tyr/utilities/replace_couchbase_server.py
@@ -1,6 +1,7 @@
 import time
 import logging
 from tyr.servers.cache import CacheServer
+import requests
 
 def timeit(method):
 


### PR DESCRIPTION
Like the `replace_mongo_server` function, this automates the replacement of a single member in a cluster.

A new Couchbase server will be spun up, added to the Couchbase cluster. If `replace` is `True`, the old server will be removed from the cluster. If `reroute` is `True` then before the old server is removed, the DNS record for the old server will be changed to point to the new server, which means that clients don't need to be immediately updated. In addition, the old server will not be removed until the updated DNS record has "propagated." If the server is being replaced, it will also be stopped, or optionally terminated. Either way, it will be placed in Maintenance Mode on Stackdriver first.