### PR TITLE
Include Region Information in Instance Names

### DIFF
--- a/tyr/servers/mongo/arbiter.py
+++ b/tyr/servers/mongo/arbiter.py
@@ -2,8 +2,8 @@ from member import MongoReplicaSetMember
 
 class MongoArbiterNode(MongoReplicaSetMember):
 
-    NAME_TEMPLATE = '{envcl}-rs{replica_set}-{zone}-arb'
-    NAME_SEARCH_PREFIX = '{envcl}-rs{replica_set}-{zone}-'
+    NAME_TEMPLATE = '{envcl}-rs{replica_set}-{location}-arb'
+    NAME_SEARCH_PREFIX = '{envcl}-rs{replica_set}-{location}-'
     NAME_AUTO_INDEX=False
 
     CHEF_RUNLIST = ['role[RoleMongo]']

--- a/tyr/servers/mongo/config.py
+++ b/tyr/servers/mongo/config.py
@@ -2,7 +2,7 @@ from node import MongoNode
 
 class MongoConfigNode(MongoNode):
 
-    NAME_TEMPLATE = '{envcl}-cfg-{zone}'
+    NAME_TEMPLATE = '{envcl}-cfg-{location}'
     NAME_SEARCH_PREFIX = '{envcl}-cfg-'
     NAME_AUTO_INDEX = False
 

--- a/tyr/servers/mongo/data.py
+++ b/tyr/servers/mongo/data.py
@@ -3,8 +3,8 @@ import sys
 
 class MongoDataNode(MongoReplicaSetMember):
 
-    NAME_TEMPLATE = '{envcl}-rs{replica_set}-{zone}-{index}'
-    NAME_SEARCH_PREFIX = '{envcl}-rs{replica_set}-{zone}-'
+    NAME_TEMPLATE = '{envcl}-rs{replica_set}-{location}-{index}'
+    NAME_SEARCH_PREFIX = '{envcl}-rs{replica_set}-{location}-'
     NAME_AUTO_INDEX=True
 
     CHEF_RUNLIST = ['role[RoleMongo]']

--- a/tyr/servers/mongo/data_warehousing.py
+++ b/tyr/servers/mongo/data_warehousing.py
@@ -2,8 +2,8 @@ from member import MongoReplicaSetMember
 
 class MongoDataWarehousingNode(MongoReplicaSetMember):
 
-    NAME_TEMPLATE = '{envcl}-rs{replica_set}-{zone}-fulla'
-    NAME_SEARCH_PREFIX = '{envcl}-rs{replica_set}-{zone}-'
+    NAME_TEMPLATE = '{envcl}-rs{replica_set}-{location}-fulla'
+    NAME_SEARCH_PREFIX = '{envcl}-rs{replica_set}-{location}-'
     NAME_AUTO_INDEX=False
 
     IAM_ROLE_POLICIES = [

--- a/tyr/servers/server.py
+++ b/tyr/servers/server.py
@@ -12,8 +12,8 @@ from tyr.policies import policies
 
 class Server(object):
 
-    NAME_TEMPLATE='{envcl}-{zone}-{index}'
-    NAME_SEARCH_PREFIX='{envcl}-{zone}-'
+    NAME_TEMPLATE='{envcl}-{location}-{index}'
+    NAME_SEARCH_PREFIX='{envcl}-{location}-'
     NAME_AUTO_INDEX=True
 
     IAM_ROLE_POLICIES = []
@@ -199,7 +199,23 @@ class Server(object):
         self.log.info('Using Chef path "{path}"'.format(
                                 path = self.chef_path))
 
+    @property
+    def location(self):
 
+        region_map = {
+                'ap-northeast-1': 'apne1',
+                'ap-southeast-1': 'apse1',
+                'ap-southeast-2': 'apse2',
+                'eu-central-1': 'euc1',
+                'eu-west-1': 'euw1',
+                'sa-east-1': 'sae1',
+                'us-east-1': 'use1',
+                'us-west-1': 'usw1',
+                'us-west-2': 'usw2',
+        }
+
+        return '{region}{zone}'.format(region=region_map[self.region],
+                                        zone=self.availability_zone[-1:])
 
     def next_index(self, supplemental={}):
 
@@ -267,8 +283,8 @@ class Server(object):
 
         supplemental = self.__dict__.copy()
 
-        supplemental['zone'] = self.availability_zone[-1:]
         supplemental['envcl'] = self.envcl
+        supplemental['location'] = self.location
 
         if self.NAME_AUTO_INDEX:
 


### PR DESCRIPTION
This includes region information in instances names along with availability zones.

Example names:

- `t-monolith-mongo-rs1-use1c-01`
- `t-monolith-cache-use1c-01`