### PR TITLE
Added ReplicaSet Tag for MongoDB Replica Members

### DIFF
--- a/tyr/servers/mongo/member.py
+++ b/tyr/servers/mongo/member.py
@@ -31,6 +31,16 @@ class MongoReplicaSetMember(MongoNode):
 
         self.log.info('Using replica set {set}'.format(set = self.replica_set))
 
+    @property
+    def tags(self):
+
+        tags = super(MongoReplicaSetMember, self).tags
+
+        tags['ReplicaSet'] = self.REPLICA_SET_TEMPLATE.format(group=self.group,
+                                                        set_ = self.replica_set)
+
+        return tags
+
     def bake(self):
 
         super(MongoReplicaSetMember, self).bake()


### PR DESCRIPTION
This resolves #22, adding an EC2 tag 'ReplicaSet' to MongoDB nodes which contains the name of the replica set.