### PR TITLE
Hosted DNS Zones Argument

### DIFF
--- a/tyr/clusters/mongo.py
+++ b/tyr/clusters/mongo.py
@@ -17,10 +17,11 @@ class MongoCluster(object):
 
     def __init__(self, group = None, server_type = None, instance_type = None,
                     environment = None, ami = None, region = None, role = None,
-                    keypair = None, chef_path = None, replica_set = None,
-                    security_groups = None, block_devices = None,
-                    data_volume_size=None, data_volume_iops=None,
-                    data_nodes=None, mongodb_version=None):
+                    keypair = None, chef_path = None, dns_zones = None,
+                    replica_set = None, security_groups = None,
+                    block_devices = None, data_volume_size=None,
+                    data_volume_iops=None, data_nodes=None,
+                    mongodb_version=None):
 
         self.nodes = []
 
@@ -40,6 +41,7 @@ class MongoCluster(object):
         self.data_volume_iops = data_volume_iops
         self.data_nodes = data_nodes
         self.mongodb_version = mongodb_version
+        self.dns_zones = dns_zones
 
     def provision(self):
 
@@ -63,6 +65,7 @@ class MongoCluster(object):
                                     ami = self.ami, region = self.region,
                                     role = self.role, keypair = self.keypair,
                                     chef_path = self.chef_path,
+                                    dns_zones = self.dns_zones,
                                     replica_set = self.replica_set,
                                     security_groups = self.security_groups,
                                     block_devices = self.block_devices,
@@ -85,6 +88,7 @@ class MongoCluster(object):
                                     ami = self.ami, region = self.region,
                                     role = self.role, keypair = self.keypair,
                                     chef_path = self.chef_path,
+                                    dns_zones = self.dns_zones,
                                     replica_set = self.replica_set,
                                     security_groups = self.security_groups,
                                     block_devices = self.block_devices,

--- a/tyr/servers/cache/server.py
+++ b/tyr/servers/cache/server.py
@@ -12,9 +12,9 @@ class CacheServer(Server):
     def __init__(self, group=None, server_type=None, instance_type=None,
                     environment=None, ami=None, region=None, role=None,
                     keypair=None, availability_zone=None, security_groups=None,
-                    block_devices=None, chef_path=None, couchbase_version=None,
-                    couchbase_username=None, couchbase_password=None,
-                    bucket_name=None):
+                    block_devices=None, chef_path=None, dns_zones=None,
+                    couchbase_version=None, couchbase_username=None,
+                    couchbase_password=None,  bucket_name=None):
 
         if server_type is None: server_type = self.SERVER_TYPE
 
@@ -27,7 +27,7 @@ class CacheServer(Server):
                                             environment, ami, region, role,
                                             keypair, availability_zone,
                                             security_groups, block_devices,
-                                            chef_path)
+                                            chef_path, dns_zones)
 
     def configure(self):
 

--- a/tyr/servers/mongo/arbiter.py
+++ b/tyr/servers/mongo/arbiter.py
@@ -13,15 +13,15 @@ class MongoArbiterNode(MongoReplicaSetMember):
                     environment = None, ami = None, region = None, role = None,
                     keypair = None, availability_zone = None,
                     security_groups = None, block_devices = None,
-                    chef_path = None, replica_set = None,
+                    chef_path = None, dns_zones = None, replica_set = None,
                     mongodb_version = None):
 
         super(MongoArbiterNode, self).__init__(group, server_type, instance_type,
                                                 environment, ami, region, role,
                                                 keypair, availability_zone,
                                                 security_groups, block_devices,
-                                                chef_path, replica_set,
-                                                mongodb_version)
+                                                chef_path, dns_zones,
+                                                replica_set, mongodb_version)
 
     def bake(self):
 

--- a/tyr/servers/mongo/config.py
+++ b/tyr/servers/mongo/config.py
@@ -13,13 +13,14 @@ class MongoConfigNode(MongoNode):
                     environment = None, ami = None, region = None, role = None,
                     keypair = None, availability_zone = None,
                     security_groups = None, block_devices = None,
-                    chef_path = None):
+                    chef_path = None, dns_zones = None):
 
         super(MongoConfigNode, self).__init__(group, server_type, instance_type,
                                                 environment, ami, region, role,
                                                 keypair, availability_zone,
                                                 security_groups,
-                                                block_devices, chef_path)
+                                                block_devices, chef_path,
+                                                dns_zones)
 
     def bake(self):
 

--- a/tyr/servers/mongo/data.py
+++ b/tyr/servers/mongo/data.py
@@ -14,7 +14,7 @@ class MongoDataNode(MongoReplicaSetMember):
                     environment = None, ami = None, region = None, role = None,
                     keypair = None, availability_zone = None,
                     security_groups = None, block_devices = None,
-                    chef_path = None, replica_set = None,
+                    chef_path = None, dns_zones = None, replica_set = None,
                     data_volume_size = None, data_volume_iops = None,
                     mongodb_version = None):
 
@@ -22,7 +22,7 @@ class MongoDataNode(MongoReplicaSetMember):
                                             environment, ami, region, role,
                                             keypair, availability_zone,
                                             security_groups, block_devices,
-                                            chef_path, replica_set,
+                                            chef_path, dns_zones, replica_set,
                                             mongodb_version)
 
         self.data_volume_size = data_volume_size

--- a/tyr/servers/mongo/data_warehousing.py
+++ b/tyr/servers/mongo/data_warehousing.py
@@ -19,7 +19,7 @@ class MongoDataWarehousingNode(MongoReplicaSetMember):
                     environment = None, ami = None, region = None, role = None,
                     keypair = None, availability_zone = None,
                     security_groups = None, block_devices = None,
-                    chef_path = None, replica_set = None,
+                    chef_path = None, dns_zones = None, replica_set = None,
                     data_volume_size = None, mongodb_version = None):
 
         super(MongoDataWarehousingNode, self).__init__(group, server_type,
@@ -29,7 +29,7 @@ class MongoDataWarehousingNode(MongoReplicaSetMember):
                                                         availability_zone,
                                                         security_groups,
                                                         block_devices,
-                                                        chef_path,
+                                                        chef_path, dns_zones,
                                                         replica_set,
                                                         mongodb_version)
 

--- a/tyr/servers/mongo/member.py
+++ b/tyr/servers/mongo/member.py
@@ -8,7 +8,7 @@ class MongoReplicaSetMember(MongoNode):
                     environment = None, ami = None, region = None, role = None,
                     keypair = None, availability_zone = None,
                     security_groups = None, block_devices = None,
-                    chef_path = None, replica_set = None,
+                    chef_path = None, dns_zones = None, replica_set = None,
                     mongodb_version = None):
 
         super(MongoReplicaSetMember, self).__init__(group, server_type, instance_type,
@@ -17,7 +17,7 @@ class MongoReplicaSetMember(MongoNode):
                                                     availability_zone,
                                                     security_groups,
                                                     block_devices, chef_path,
-                                                    mongodb_version)
+                                                    dns_zones, mongodb_version)
 
         self.replica_set = replica_set
 

--- a/tyr/servers/mongo/node.py
+++ b/tyr/servers/mongo/node.py
@@ -14,7 +14,7 @@ class MongoNode(Server):
                     environment = None, ami = None, region = None, role = None,
                     keypair = None, availability_zone = None,
                     security_groups = None, block_devices = None,
-                    chef_path = None, mongodb_version=None):
+                    chef_path = None, dns_zones = None, mongodb_version=None):
 
         self.mongodb_version = mongodb_version
 
@@ -24,7 +24,7 @@ class MongoNode(Server):
                                         environment, ami, region, role,
                                         keypair, availability_zone,
                                         security_groups, block_devices,
-                                        chef_path)
+                                        chef_path, dns_zones)
 
     def configure(self):
 

--- a/tyr/servers/server.py
+++ b/tyr/servers/server.py
@@ -216,6 +216,19 @@ class Server(object):
                             'value': '{dns_name}'
                         }
                     ]
+                },
+                {
+                    'id': {
+                        'prod': 'Z1LKTAOOYM3H8T',
+                        'test': 'ZXXFTW7F1WFIS'
+                    },
+                    'records': [
+                        {
+                            'type': 'A',
+                            'name': '{hostname}.',
+                            'value': '{private_ip_address}'
+                        }
+                    ]
                 }
             ]
 

--- a/tyr/servers/server.py
+++ b/tyr/servers/server.py
@@ -226,9 +226,9 @@ class Server(object):
                     },
                     'records': [
                         {
-                            'type': 'A',
+                            'type': 'CNAME',
                             'name': '{hostname}.',
-                            'value': '{private_ip_address}',
+                            'value': '{private_dns_name}',
                             'ttl': 60
                         }
                     ]

--- a/tyr/servers/server.py
+++ b/tyr/servers/server.py
@@ -648,7 +648,7 @@ named {name}""".format(path = d['path'], name = d['name']))
                 formatting_params = {
                     'hostname': self.hostname,
                     'name': self.name,
-                    'id': self.instance.id,
+                    'instance_id': self.instance.id,
                     'vpc_id': self.instance.vpc_id,
                     'ip_address': self.instance.ip_address,
                     'dns_name': self.instance.dns_name,

--- a/tyr/servers/server.py
+++ b/tyr/servers/server.py
@@ -213,7 +213,8 @@ class Server(object):
                         {
                             'type': 'CNAME',
                             'name': '{hostname}.',
-                            'value': '{dns_name}'
+                            'value': '{dns_name}',
+                            'ttl': 60
                         }
                     ]
                 },
@@ -226,7 +227,8 @@ class Server(object):
                         {
                             'type': 'A',
                             'name': '{hostname}.',
-                            'value': '{private_ip_address}'
+                            'value': '{private_ip_address}',
+                            'ttl': 60
                         }
                     ]
                 }
@@ -662,7 +664,8 @@ named {name}""".format(path = d['path'], name = d['name']))
                     self.log.info('The existing DNS record was deleted')
 
                 try:
-                    zone.add_record(record['type'], name, value)
+                    zone.add_record(record['type'], name, value,
+                                    ttl=record['ttl'])
                     self.log.info('Added new DNS record')
                 except Exception, e:
                     self.log.error(str(e))

--- a/tyr/servers/server.py
+++ b/tyr/servers/server.py
@@ -215,6 +215,12 @@ class Server(object):
                             'name': '{name}.external.{dns_zone}.',
                             'value': '{dns_name}',
                             'ttl': 60
+                        },
+                        {
+                            'type': 'CNAME',
+                            'name': '{hostname}.',
+                            'value': '{private_dns_name}',
+                            'ttl': 60
                         }
                     ]
                 },

--- a/tyr/servers/server.py
+++ b/tyr/servers/server.py
@@ -647,7 +647,8 @@ named {name}""".format(path = d['path'], name = d['name']))
                     'ip_address': self.instance.ip_address,
                     'dns_name': self.instance.dns_name,
                     'private_ip_address': self.instance.private_ip_address,
-                    'private_dns_name': self.instance.private_dns_name
+                    'private_dns_name': self.instance.private_dns_name,
+                    'dns_zone': self.hostname[len(self.name)+1:]
                 }
 
                 name = record['name'].format(**formatting_params)

--- a/tyr/servers/server.py
+++ b/tyr/servers/server.py
@@ -212,7 +212,7 @@ class Server(object):
                     'records': [
                         {
                             'type': 'CNAME',
-                            'name': '{hostname}.',
+                            'name': '{name}.external.{dns_zone}.',
                             'value': '{dns_name}',
                             'ttl': 60
                         }

--- a/tyr/servers/server.py
+++ b/tyr/servers/server.py
@@ -221,6 +221,7 @@ class Server(object):
                 {
                     'id': {
                         'prod': 'Z1LKTAOOYM3H8T',
+                        'stage': 'Z24UEMQ8K6Z50Z',
                         'test': 'ZXXFTW7F1WFIS'
                     },
                     'records': [


### PR DESCRIPTION
Previously, DNS zones and records were automatically created using the zone from the instance's hostname and the public DNS hostname provided by Amazon.

For example, a server with the hostname `t-monolith-mongo-c-01.thorhudl.com` with the EC2 public DNS hostname `ec2-76-168-127-141.compute-1.amazonaws.com` automatically created a CNAME record in the hosted zone `thorhudl.com.` with the name `t-monolith-mongo-c-01.thorhudl.com.` and the value `ec2-76-168-127-141.compute-1.amazonaws.com`.

Now, complex DNS records can be created across multiple hosted zones by using the `dns_zones` argument. For example, here is the default value for the argument:

```python
[
    {
        'id': {
            'prod': 'ZDQ066NWSBGCZ',
            'stage': 'Z3ETV7KVCRERYL',
            'test': 'ZAH3O4H1900GY'
        },
        'records': [
            {
                'type': 'CNAME',
                'name': '{hostname}.',
                'value': '{dns_name}',
                'ttl': 60
            }
        ]
    },
    {
        'id': {
            'prod': 'Z1LKTAOOYM3H8T',
            'stage': 'Z24UEMQ8K6Z50Z',
            'test': 'ZXXFTW7F1WFIS'
        },
        'records': [
            {
                'type': 'A',
                'name': '{hostname}.',
                'value': '{private_ip_address}',
                'ttl': 60
            }
        ]
    }
]
```

If that same server, `t-monolith-mongo-c-01.thorhudl.com`, was recreated and it had the private IP address `10.10.12.13`, there would now be two DNS records created for it.

1. In the zone `ZAH3O4H1900GY` with the name `t-monolith-mongo-c-01.thorhudl.com.` and the value `ec2-76-168-127-141.compute-1.amazonaws.com`.
2. In the zone `ZXXFTW7F1WFIS` with the name `t-monolith-mongo-c-01.thorhudl.com.` and the value `10.10.12.13`.

Multiple zones with the different ID's for different ID's can be specified, with multiple records defined per zone. Each record's `name` and `value` can be a template with the following variables:

| Variable | Value | Example |
|:-----------|:--------|:-------------|
| `hostname` | The instance's hostname | `t-monolith-mongo-c-01.thorhudl.com` |
| `name` | The instance's name | `t-monolith-mongo-c-01` |
| `id` | The instance's ID | `i-4362e23u` |
| `vpc_id` | The ID of the VPC the instance is in | `vpc-2j4539h5` |
| `ip_address` | The public IPv4 address assigned by EC2 | `76.168.127.141` |
| `dns_name` | The public DNS record provided by EC2 | `ec2-76-168-127-141.compute-1.amazonaws.com` |
| `private_ip_address` | The private IP address provided by EC2 | `10.10.12.13` |
| `private_dns_name` | The private DNS record provided by EC2 | `ip-10-10-12-13.ec2.internal` |