### PR TITLE
Respect Default Server Properties when Replacing Servers

### DIFF
--- a/tyr/utilities/replace_mongo_server.py
+++ b/tyr/utilities/replace_mongo_server.py
@@ -262,21 +262,7 @@ def launch_server(environment, group, instance_type, availability_zone,
                     replica_set, data_volume_size, data_volume_iops,
                     mongodb_package_version, node_type, replica_set_template):
 
-    log.debug('Preparing to launch a new node with the following properties:')
-
-    log.debug('Node Type: {node_type}'.format(node_type = node_type))
-    log.debug('Environment: {environment}'.format(environment = environment))
-    log.debug('Group: {group}'.format(group = group))
-    log.debug('Instance Type: {instance_type}'.format(
-                                                instance_type = instance_type))
-    log.debug('Availability Zone: {zone}'.format(zone = availability_zone))
-    log.debug('Replica Set: {replica_set}'.format(replica_set = replica_set))
-    log.debug('Replica Set Name: {replica_set_template}'.format(
-                                replica_set_template = replica_set_template))
-    log.debug('Data Volume Size: {size}'.format(size = data_volume_size))
-    log.debug('Data Volume IOPS: {iops}'.format(iops = data_volume_iops))
-    log.debug('MongoDB Package Version: {version}'.format(
-                                            version = mongodb_package_version))
+    log.debug('Preparing to launch a new node')
 
     node = None
 

--- a/tyr/utilities/replace_mongo_server.py
+++ b/tyr/utilities/replace_mongo_server.py
@@ -522,12 +522,12 @@ def stop_decommissioned_node(address, terminate=False,
             log.debug('Failed to stop {instance}'.format(
                                                         instance = instance_id))
 @timeit
-def replace_server(environment = 'stage', group = 'monolith',
-                    instance_type = 'm3.medium', availability_zone = 'c',
-                    replica_set_index = 1, data_volume_size = 400,
-                    data_volume_iops = 2000, mongodb_package_version = '2.4.13',
-                    member = None, replace = False, node_type = 'data',
-                    replica_set_template=None, reroute=False, terminate=False,
+def replace_server(environment=None, group='monolith', instance_type=None,
+                    availability_zone=None, replica_set_index=None,
+                    data_volume_size=None, data_volume_iops=None,
+                    mongodb_package_version=None, member=None,
+                    replace=False, node_type='data', reroute=False,
+                    replica_set_template=None, terminate=False,
                     prompt_before_replace=True):
 
     if member is None:


### PR DESCRIPTION
As mentioned in #34, the default value for the IOPS on data volume in a MongoDB data node is `3000` in production and `0` otherwise. However, the default value of the argument in the `replace_server` function on the `tyr.utilities.replace_mongo_server` module is `2000` which means that unless otherwise specified, data volumes in test, staging, and production environments are spun up with `2000` IOPS.

This sets arguments used to spin up the new node which have default values specified in the module that represents that node to have default values of `None` so that those default values are respected. However, this means that we can't be sure that those arguments will have values before we proceed to spin up the node, which renders the log statements with the properties to be used in the node's creation useless in most cases - it would just print `None` unless the argument was being explicitly defined.

For this reason, I've removed those statements. Those values are still visible in the log statements which are emitted when the node is being configured.