### PR TITLE
MongoDB Migration Hot Fixes

### DIFF
--- a/tyr/servers/server.py
+++ b/tyr/servers/server.py
@@ -812,8 +812,12 @@ named {name}""".format(path = d['path'], name = d['name']))
 
         while True:
             try:
+                keys = ['~/.ssh/stage', '~/.ssh/prod']
+                keys = [os.path.expanduser(key) for key in keys]
+
                 connection.connect(self.instance.private_dns_name,
-                                    username = 'ec2-user')
+                                    username='ec2-user',
+                                    key_filename=keys)
                 break
             except Exception:
                 self.log.warn('Unable to establish SSH connection')

--- a/tyr/servers/server.py
+++ b/tyr/servers/server.py
@@ -806,7 +806,7 @@ named {name}""".format(path = d['path'], name = d['name']))
 
         while True:
             try:
-                connection.connect(self.instance.public_dns_name,
+                connection.connect(self.instance.private_dns_name,
                                     username = 'ec2-user')
                 break
             except Exception:

--- a/tyr/servers/server.py
+++ b/tyr/servers/server.py
@@ -727,7 +727,7 @@ named {name}""".format(path = d['path'], name = d['name']))
         self.ec2.create_tags([self.instance.id], self.tags)
         self.log.info('Tagged instance with {tags}'.format(tags=self.tags))
 
-    def route(self):
+    def route(self, wait=False):
 
         for dns_zone in self.dns_zones:
 
@@ -772,8 +772,14 @@ named {name}""".format(path = d['path'], name = d['name']))
                     self.log.info('The existing DNS record was deleted')
 
                 try:
-                    zone.add_record(record['type'], name, value,
-                                    ttl=record['ttl'])
+                    status = zone.add_record(record['type'], name, value,
+                                                ttl=record['ttl'])
+
+                    if wait:
+                        while status.update() != 'INSYNC':
+                            self.log.debug('Waiting for DNS change to propagate')
+                            time.sleep(10)
+
                     self.log.info('Added new DNS record')
                 except Exception, e:
                     self.log.error(str(e))

--- a/tyr/utilities/replace_mongo_server.py
+++ b/tyr/utilities/replace_mongo_server.py
@@ -440,7 +440,7 @@ def wait_for_sync(node):
 
     while True:
 
-        status = run_mongo_command(node.instance.public_dns_name, 'rs.status()')
+        status = run_mongo_command(node.instance.private_dns_name, 'rs.status()')
 
         if status['ok'] != 1:
 
@@ -591,7 +591,7 @@ def replace_server(environment=None, group=None, instance_type=None,
 
             log.debug('The tag Name could not be found on the instance')
 
-            public_address = instance.public_dns_name
+            public_address = instance.private_dns_name
 
         log.debug('Proceeding using {address} to contact the primary'.format(
                                                     address = public_address))

--- a/tyr/utilities/replace_mongo_server.py
+++ b/tyr/utilities/replace_mongo_server.py
@@ -206,8 +206,11 @@ def run_command(address, command):
 
     while True:
         try:
-            connection.connect(address,
-                                username = 'ec2-user')
+            keys = ['~/.ssh/stage', '~/.ssh/prod']
+            keys = [os.path.expanduser(key) for key in keys]
+
+            connection.connect(address, username='ec2-user',
+                                key_filename=keys)
             break
         except Exception:
             log.warn('Unable to establish an SSH connection')

--- a/tyr/utilities/replace_mongo_server.py
+++ b/tyr/utilities/replace_mongo_server.py
@@ -739,4 +739,5 @@ def replace_server(environment=None, group=None, instance_type=None,
                 log.debug('An existing DNS record does not exist')
             else:
                 log.debug('Updating the DNS CNAME record')
-                zone.update_cname(member+'.', node.instance.public_dns_name)
+                zone.update_cname(member+'.', node.instance.private_dns_name)
+


### PR DESCRIPTION
These are various fixes which are _already_ in use on the `p-infra-comm` box which were necessary to

1. Have the MongoDB migration module work with a VPC
2. Have the project run on a Linux machine

This:

- Adds support for waiting on DNS propagation when spinning up a node
- Establishes SSH connections over private IP
- Passes in SSH private key paths when establishing SSH connections
- Uses the private DNS name when claiming a replaced nodes DNS record