### PR TITLE
Change MongoDB Port for Config Servers to 27019

### DIFF
--- a/tyr/servers/mongo/config.py
+++ b/tyr/servers/mongo/config.py
@@ -49,5 +49,8 @@ class MongoConfigNode(MongoNode):
 
             self.log.info('Configured the hudl_ebs.volumes attribute')
 
+            self.chef_node.attributes.set_dotted('mongodb.config.port', 27019)
+            self.log.info('Set the MongoDB port to 27019')
+
             self.chef_node.save()
             self.log.info('Saved the Chef Node configuration')


### PR DESCRIPTION
This fixes issue #47 which notes that config servers are currently configured to use `27018` for their MongoDB port. They should be using `27019`.