### PR TITLE
Change Default Instance Type to t2.medium

### DIFF
--- a/tyr/servers/server.py
+++ b/tyr/servers/server.py
@@ -71,7 +71,7 @@ class Server(object):
 
         if self.instance_type is None:
             self.log.warn('No Instance Type provided')
-            self.instance_type = 'm3.medium'
+            self.instance_type = 't2.medium'
 
         self.log.info('Using Instance Type "{instance_type}"'.format(
                                             instance_type = self.instance_type))


### PR DESCRIPTION
As noted in issue #45, now that we are running inside the VPC and have access to the `t2` instance class, we should be using the `t2.medium` instance by default instead of `m3.medium`.