### PR TITLE
Mind the Gap - OSS Badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 ## Tyr
+[![](https://img.shields.io/badge/hudl-OSS-orange.svg)](http://hudl.github.io/)
 
 Tyr is a Python library used internally at Hudl to automate the task of spinning
 up individual servers as well as different types of clusters.


### PR DESCRIPTION
This will add a badge to this project to signify it's an open source software project. Clicking the badge links to the new Hudl OSS page.
# NOT READY FOR MERGE UNTIL PAGE IS DEPLOYED