### PR TITLE
adding hint into bootstrap so we get ec2 attributes on 1st chef run

### DIFF
--- a/tyr/servers/server.py
+++ b/tyr/servers/server.py
@@ -384,6 +384,8 @@ sed -i '/requiretty/d' /etc/sudoers
 hostname {hostname}
 mkdir /etc/chef
 touch /etc/chef/client.rb
+mkdir -p /etc/chef/ohai/hints
+touch /etc/chef/ohai/hints/ec2.json
 echo '{validation_key}' > /etc/chef/validation.pem
 echo 'chef_server_url "http://chef.app.hudl.com/"
 node_name "{name}"


### PR DESCRIPTION
I was doing this in role_base, but if this hint file ec2.json doesn't already exist before the 1st chef run the attributes don't populate.  If it's in role_base it takes 2 runs to get the attributes.