### PR TITLE
Handle Error Cases when Accessing the Primary using db.isMaster()

### DIFF
--- a/tyr/utilities/replace_mongo_server.py
+++ b/tyr/utilities/replace_mongo_server.py
@@ -56,15 +56,15 @@ class ReplicaSet(object):
         try:
             primary = response['primary'].split(':')[0]
         except TypeError as e:
-            log.critical(e)
+            log.critical(str(e))
             log.critical('The response from MongoDB was not a JSON object.')
             sys.exit(1)
         except KeyError as e:
-            log.critical(e)
+            log.critical(str(e))
             log.critical('The primary property was not defined.')
             sys.exit(1)
         except AttributeError as e:
-            log.critical(e)
+            log.critical(str(e))
             log.critical('The primary property is not a string.')
             sys.exit(1)
 

--- a/tyr/utilities/replace_mongo_server.py
+++ b/tyr/utilities/replace_mongo_server.py
@@ -52,7 +52,21 @@ class ReplicaSet(object):
 
         log.debug('Using db.isMaster() to determine the primary')
         response = run_mongo_command(member, 'db.isMaster()')
-        primary = response['primary'].split(':')[0]
+
+        try:
+            primary = response['primary'].split(':')[0]
+        except TypeError as e:
+            log.critical(e)
+            log.critical('The response from MongoDB was not a JSON object.')
+            sys.exit(1)
+        except KeyError as e:
+            log.critical(e)
+            log.critical('The primary property was not defined.')
+            sys.exit(1)
+        except AttributeError as e:
+            log.critical(e)
+            log.critical('The primary property is not a string.')
+            sys.exit(1)
 
         self.primary = primary
 


### PR DESCRIPTION
Previous discussion from #62 and #63.

> @Z3r0Sum so I'm not sure what the output of `db.isMaster()` looks like when there is no master. If it just throws an error that isn't JSON formatted, then

> ```python
primary = response['primary'].split(':')[0]
```

> would throw a `TypeError`.

> If it throws a JSON formatted error or if the `primary` key was simply omitted, that line would throw a `KeyError`. 

> If it returns JSON which has the `primary` key defined, `self.primary` would be set to that value and when an attempt to interact with the replica set is made in the future, we would probably get errors about it being unable to SSH into the primary.

This does not handle the case where the `primary` property is defined and is a string, but not actually a valid primary.