### PR TITLE
Feature - add ability to rebuild Postfix Master servers.

### DIFF
--- a/tyr/servers/postfix/__init__.py
+++ b/tyr/servers/postfix/__init__.py
@@ -1,0 +1,1 @@
+from master import PostfixMaster

--- a/tyr/servers/postfix/master.py
+++ b/tyr/servers/postfix/master.py
@@ -1,14 +1,17 @@
 from tyr.servers.server import Server
+from tyr.utilities.replace_mongo_server import stop_decommissioned_node
 import chef
-import os.path
 import sys
 import re
+import os
 
 class PostfixMaster(Server):
 
-    SERVER_TYPE  = 'postfix'
-    CHEF_RUNLIST = ['role[RolePostfix]']
-    ELASTIC_IP   = ''
+    SERVER_TYPE          = 'postfix'
+    CHEF_RUNLIST         = ['role[RolePostfix]']
+    ELASTIC_IP           = ''
+    STACKDRIVER_API_KEY  = os.environ.get('STACKDRIVER_API_KEY', False)
+    STACKDRIVER_USERNAME = os.environ.get('STACKDRIVER_USERNAME', False)
 
     def __init__(self, group=None, server_type=None, instance_type=None,
                  environment=None, ami=None, region=None, role=None,
@@ -21,28 +24,27 @@ class PostfixMaster(Server):
             server_type = self.SERVER_TYPE
 
         super(PostfixMaster, self).__init__(group, server_type, instance_type,
-                                        environment, ami, region, role,
-                                        keypair, availability_zone,
-                                        security_groups, block_devices,
-                                        chef_path, subnet_id, dns_zones)
+                                            environment, ami, region, role,
+                                            keypair, availability_zone,
+                                            security_groups, block_devices,
+                                            chef_path, subnet_id, dns_zones)
 
-        if mail_name is not None:
-            if re.match('^.+hudl\.com$',mail_name) is None:
-                self.mail_name = mail_name + '.hudl.com'
+        try:
+            if mail_name is not None:
+                if re.match('^.+hudl\.com$',mail_name) is None:
+                    self.mail_name = mail_name + '.hudl.com'
+                else:
+                    self.mail_name = mail_name
             else:
-                self.mail_name = mail_name
-        else:
-            raise Exception('Must pass existing mail server name!')
+                raise Exception('Must pass existing mail server name!')
+        except Exception,e:
+            self.log.critical(str(e))
+            raise e
             sys.exit(1)
 
     def configure(self):
         super(PostfixMaster, self).configure()
-        """
-        1.) Verify that the mail server name exists in DNS and there's an EIP
-        associated with it.
-        - Cannot assign the IP until there's an instance ID.
-        """
-        #Check for mail server name in AWS and to see if it has an EIP.
+
         if self.mail_name:
             route53_conn = self.route53
             elastic_ip   = self.check_mail_server(route53_conn)
@@ -52,13 +54,12 @@ class PostfixMaster(Server):
             self.log.critical('Must specify a mail server configured in route53!')
             sys.exit(1)
 
-
-    # Params: Route53 connection object from boto
-    # Return: EIP
     def check_mail_server(self,route53_conn):
-        """
-        Use zone object for hudl.com to search for A records that match the
-        supplied mail server name.
+        """Verify the mail server exists in DNS ans has an EIP
+
+        :param route53_conn: The route53 boto object.
+        :type route53_conn: obj.
+        :returns: str -- A string with the elastic IP.
         """
         hosted_zone    = 'hudl.com'
         zone_obj       = route53_conn.get_zone(hosted_zone)
@@ -75,31 +76,26 @@ class PostfixMaster(Server):
                                 'route53!'.format(mail_name=self.mail_name))
         except Exception, e:
             self.log.critical(str(e))
+            raise e
             sys.exit(1)
 
         return elastic_ip
 
-    # Assigns an EIP to an instance
     def assign_eip(self):
+        """Assigns an EIP to an instance"""
         ec2_conn    = self.ec2
         instance_id = self.instance.id
+        address     = self.instance.ip_address
 
         try:
             alloc_id = self.get_alloc_id(ec2_conn)
-            if alloc_id is None:
-                raise Exception('The EIP associated with the DNS name for '
-                                '{mail_name} does not have an allocation ID '
-                                'associated with it. This issue can be resolved '
-                                'by migrating the EIP from EC2-Classic to '
-                                'EC2-VPC.'.format(mail_name=self.mail_name))
-
-            result = ec2_conn.associate_address(instance_id=instance_id,
-                                                public_ip=None,
-                                                allocation_id=alloc_id,
-                                                network_interface_id=None,
-                                                private_ip_address=None,
-                                                allow_reassociation=True,
-                                                dry_run=False)
+            result   = ec2_conn.associate_address(instance_id=instance_id,
+                                                  public_ip=None,
+                                                  allocation_id=alloc_id,
+                                                  network_interface_id=None,
+                                                  private_ip_address=None,
+                                                  allow_reassociation=True,
+                                                  dry_run=False)
             if result:
                 self.log.info('Successfully assigned EIP: {elastic_ip} '
                               'to {mail_name}'.format(elastic_ip=elastic_ip,
@@ -108,11 +104,21 @@ class PostfixMaster(Server):
                 raise Exception('Unable to assign EIP: {eip}! '
                                 'Exiting...'.format(eip=elastic_ip))
         except Exception,e:
-            self.log.error(str(e))
+            self.log.critical(str(e))
+            self.terminate_node(address)
+            raise e
+            sys.exit(1)
 
-    # Params: Take the boto.ec2.connection object
-    # Return: the allocation ID that's associated with an EIP (must be in VPC)
     def get_alloc_id(self,ec2_conn):
+        """Determine the allocation ID for an EIP.
+
+        :param ec2_conn: The boto ec2 connection object.
+        :type ec2_conn: obj.
+        :returns: str -- the allocation ID
+        """
+
+        address  = self.instance.ip_address
+        alloc_id = None
         try:
             eip_addresses = ec2_conn.get_all_addresses()
 
@@ -123,27 +129,43 @@ class PostfixMaster(Server):
                     alloc_id = address_obj.allocation_id
                     break
 
+            if alloc_id is None:
+                raise Exception('The EIP associated with the DNS name for '
+                                '{mail_name} does not have an allocation ID '
+                                'associated with it. This issue can be resolved '
+                                'by migrating the EIP from EC2-Classic to '
+                                'EC2-VPC.'.format(mail_name=self.mail_name))
+
         except Exception,e:
-            self.log.error(str(e))
+            self.log.critical(str(e))
+            self.terminate_node(address)
+            raise e
+            sys.exit(1)
 
         return alloc_id
 
+    def terminate_node(self,address):
+        stop_decommissioned_node(address=address,terminate=True,
+                                 stackdriver_username=self.STACKDRIVER_USERNAME,
+                                 stackdriver_api_key=self.STACKDRIVER_API_KEY)
+
     def bake(self):
+        """ Add the myhostname attribute for the main.cf postfix config"""
+
         super(PostfixMaster, self).bake()
 
-        # Add the myhostname attribute for the main.cf postfix config
         with self.chef_api:
             self.chef_node.attributes.set_dotted('postfix.main.myhostname',
                                                  self.mail_name)
             self.log.info('Set the mail hostname value in main.cf to '
                           '{mail_name}'.format(mail_name=self.mail_name))
-
             self.chef_node.save()
             self.log.info('Saved the Chef node configuration')
 
     def autorun(self):
+        """Asign the EIP after the instance is up and configured."""
+
         super(PostfixMaster, self).autorun()
 
-        # Must assign the EIP after the instance is up and configured.
         if self.baked():
            self.assign_eip()

--- a/tyr/servers/postfix/master.py
+++ b/tyr/servers/postfix/master.py
@@ -40,8 +40,7 @@ class PostfixMaster(Server):
         super(PostfixMaster, self).configure()
 
         if self.mail_name:
-            elastic_ip = self.check_mail_server()
-            self.ELASTIC_IP = elastic_ip
+            self.ELASTIC_IP = self.check_mail_server()
             self.log.info('Found mail server!')
         else:
             self.log.critical('Must specify a mail server configured in '

--- a/tyr/servers/postfix/master.py
+++ b/tyr/servers/postfix/master.py
@@ -1,0 +1,101 @@
+from tyr.servers.server import Server
+import chef
+import os.path
+import sys
+import re
+
+class PostfixMaster(Server):
+
+    SERVER_TYPE = 'postfix'
+    CHEF_RUNLIST = ['role[RolePostfix]']
+
+    #IAM_ROLE_POLICIES = [ ]
+
+    def __init__(self, group=None, server_type=None, instance_type=None,
+                 environment=None, ami=None, region=None, role=None,
+                 keypair=None, availability_zone=None,
+                 security_groups=None, block_devices=None,
+                 chef_path=None, subnet_id=None, dns_zones=None,
+                 mail_name=None):
+
+        if re.match('^.+hudl\.com$',mail_name) is None:
+            self.mail_name = mail_name + '.hudl.com'
+        else:
+            self.mail_name = mail_name
+
+        if server_type is None:
+            server_type = self.SERVER_TYPE
+
+        super(PostfixMaster, self).__init__(group, server_type, instance_type,
+                                        environment, ami, region, role,
+                                        keypair, availability_zone,
+                                        security_groups, block_devices,
+                                        chef_path, subnet_id, dns_zones)
+
+    def configure(self):
+        super(PostfixMaster, self).configure()
+
+        #Check for mail server name in AWS and to see if it has an EIP.
+        if self.mail_name:
+            route53_conn = self.establish_route53_connection()
+            elastic_ip   = self.check_mail_server(route53_conn)
+            self.log.info('Found mail server!')
+            # Assign the elastic ip to the instance.
+            self.assign_eip(elastic_ip)
+        else:
+            self.log.critical('Must specify a mail server configured in route53!')
+            sys.exit(1)
+
+    # Params: Route53 connection object from boto
+    # Return: EIP
+    def check_mail_server(self,route53_conn):
+        """
+        Use zone object for hudl.com to search for A records that match the
+        supplied mail server name.
+        """
+        hosted_zone    = 'hudl.com'
+        zone_obj       = conn.get_zone(hosted_zone)
+        try:
+            a_record = zone_obj.get_a(self.mail_name)
+            if a_record:
+                a_record_str    = str(a_record)
+                a_record_format = a_record_str.translate(None, '<>')
+                elastic_ip      = a_record_format.split(':')[3]
+                self.log.info('Using Elastic IP {elastic_ip}...'.format(
+                                                    elastic_ip=elastic_ip))
+            else:
+                raise 'Unable to find mail server in route53!'
+        except Exception, e:
+            self.log.critical(str(e))
+            sys.exit(1)
+
+        return elastic_ip
+
+    def assign_eip(self,elastic_ip):
+        ec2_conn    = self.establish_ec2_connection()
+        instance_id = self.instance.id
+        try:
+            result = ec2_conn.associate_address(instance_id,elastic_ip,None,None,
+                                                None,True,True)
+            if result:
+                self.log.info('Successfully assigned EIP: {elastic_ip} '
+                              'to {mail_name}'.format(elastic_ip=elastic_ip,
+                                                      mail_name=self.mail_name))
+            else:
+                raise 'Unable to assign EIP! Exiting...'
+        except Exception,e:
+            self.log.critical(str(e))
+            sys.exit(1)
+
+
+    def bake(self):
+        super(PostfixMaster, self).bake()
+
+        with self.chef_api:
+            self.chef_node.attributes.set_dotted('postfix.main.myhostname',
+                                                 self.mail_name)
+            self.log.info('Set the mail hostname value in main.cf to '
+                          '{mail_name}'.format(mail_name=self.mail_name))
+
+            self.chef_node.save()
+            self.log.info('Saved the Chef node configuration')

--- a/tyr/servers/postfix/master.py
+++ b/tyr/servers/postfix/master.py
@@ -1,5 +1,4 @@
 from tyr.servers.server import Server
-from tyr.utilities.replace_mongo_server import stop_decommissioned_node
 import chef
 import sys
 import re

--- a/tyr/servers/postfix/master.py
+++ b/tyr/servers/postfix/master.py
@@ -10,8 +10,6 @@ class PostfixMaster(Server):
     CHEF_RUNLIST = ['role[RolePostfix]']
     ELASTIC_IP   = ''
 
-    #IAM_ROLE_POLICIES = [ ]
-
     def __init__(self, group=None, server_type=None, instance_type=None,
                  environment=None, ami=None, region=None, role=None,
                  keypair=None, availability_zone=None,

--- a/tyr/servers/postfix/master.py
+++ b/tyr/servers/postfix/master.py
@@ -6,8 +6,9 @@ import re
 
 class PostfixMaster(Server):
 
-    SERVER_TYPE = 'postfix'
+    SERVER_TYPE  = 'postfix'
     CHEF_RUNLIST = ['role[RolePostfix]']
+    ELASTIC_IP   = ''
 
     #IAM_ROLE_POLICIES = [ ]
 
@@ -18,11 +19,6 @@ class PostfixMaster(Server):
                  chef_path=None, subnet_id=None, dns_zones=None,
                  mail_name=None):
 
-        if re.match('^.+hudl\.com$',mail_name) is None:
-            self.mail_name = mail_name + '.hudl.com'
-        else:
-            self.mail_name = mail_name
-
         if server_type is None:
             server_type = self.SERVER_TYPE
 
@@ -32,19 +28,32 @@ class PostfixMaster(Server):
                                         security_groups, block_devices,
                                         chef_path, subnet_id, dns_zones)
 
+        if mail_name is not None:
+            if re.match('^.+hudl\.com$',mail_name) is None:
+                self.mail_name = mail_name + '.hudl.com'
+            else:
+                self.mail_name = mail_name
+        else:
+            raise Exception('Must pass existing mail server name!')
+            sys.exit(1)
+
     def configure(self):
         super(PostfixMaster, self).configure()
-
+        """
+        1.) Verify that the mail server name exists in DNS and there's an EIP
+        associated with it.
+        - Cannot assign the IP until there's an instance ID.
+        """
         #Check for mail server name in AWS and to see if it has an EIP.
         if self.mail_name:
-            route53_conn = self.establish_route53_connection()
+            route53_conn = self.route53
             elastic_ip   = self.check_mail_server(route53_conn)
+            self.ELASTIC_IP = elastic_ip
             self.log.info('Found mail server!')
-            # Assign the elastic ip to the instance.
-            self.assign_eip(elastic_ip)
         else:
             self.log.critical('Must specify a mail server configured in route53!')
             sys.exit(1)
+
 
     # Params: Route53 connection object from boto
     # Return: EIP
@@ -54,7 +63,7 @@ class PostfixMaster(Server):
         supplied mail server name.
         """
         hosted_zone    = 'hudl.com'
-        zone_obj       = conn.get_zone(hosted_zone)
+        zone_obj       = route53_conn.get_zone(hosted_zone)
         try:
             a_record = zone_obj.get_a(self.mail_name)
             if a_record:
@@ -64,29 +73,59 @@ class PostfixMaster(Server):
                 self.log.info('Using Elastic IP {elastic_ip}...'.format(
                                                     elastic_ip=elastic_ip))
             else:
-                raise 'Unable to find mail server in route53!'
+                raise Exception('Unable to find mail server {mail_name} in '
+                                'route53!'.format(mail_name=self.mail_name))
         except Exception, e:
             self.log.critical(str(e))
             sys.exit(1)
 
         return elastic_ip
 
-    def assign_eip(self,elastic_ip):
-        ec2_conn    = self.establish_ec2_connection()
+    def assign_eip(self):
+        ec2_conn    = self.ec2
         instance_id = self.instance.id
+
         try:
-            result = ec2_conn.associate_address(instance_id,elastic_ip,None,None,
-                                                None,True,True)
+            alloc_id = self.get_alloc_id(ec2_conn)
+            if alloc_id is None:
+                raise Exception('The EIP associated with the DNS name for '
+                                '{mail_name} does not have an allocation ID '
+                                'associated with it. This issue can be resolved '
+                                'by migrating the EIP from EC2-Classic to '
+                                'EC2-VPC.'.format(mail_name=self.mail_name))
+
+            result = ec2_conn.associate_address(instance_id=instance_id,
+                                                public_ip=None,
+                                                allocation_id=alloc_id,
+                                                network_interface_id=None,
+                                                private_ip_address=None,
+                                                allow_reassociation=True,
+                                                dry_run=True)
             if result:
                 self.log.info('Successfully assigned EIP: {elastic_ip} '
                               'to {mail_name}'.format(elastic_ip=elastic_ip,
                                                       mail_name=self.mail_name))
             else:
-                raise 'Unable to assign EIP! Exiting...'
+                raise Exception('Unable to assign EIP: {eip}! '
+                                'Exiting...'.format(eip=elastic_ip))
         except Exception,e:
-            self.log.critical(str(e))
-            sys.exit(1)
+            self.log.error(str(e))
 
+    def get_alloc_id(self,ec2_conn):
+        try:
+            eip_addresses = ec2_conn.get_all_addresses()
+
+            for address_obj in eip_addresses:
+                address_str = str(address_obj)
+                ip = address_str.split(':')[1]
+                if ip == self.ELASTIC_IP:
+                    alloc_id = address_obj.allocation_id
+                    break
+
+        except Exception,e:
+            self.log.error(str(e))
+
+        return alloc_id
 
     def bake(self):
         super(PostfixMaster, self).bake()
@@ -99,3 +138,9 @@ class PostfixMaster(Server):
 
             self.chef_node.save()
             self.log.info('Saved the Chef node configuration')
+
+    def autorun(self):
+        super(PostfixMaster, self).autorun()
+
+        if self.baked():
+           self.assign_eip()

--- a/tyr/servers/postfix/master.py
+++ b/tyr/servers/postfix/master.py
@@ -160,7 +160,7 @@ class PostfixMaster(Server):
 
     def autorun(self):
         """
-        Asign the EIP after the instance is up and configured.
+        Assign the EIP after the instance is up and configured.
         """
 
         super(PostfixMaster, self).autorun()

--- a/tyr/servers/server.py
+++ b/tyr/servers/server.py
@@ -878,8 +878,8 @@ named {name}""".format(path=d['path'], name=d['name']))
         instance_id = self.instance.id
 
         self.log.info('The instance ID is {id_}'.format(id_=instance_id))
-        #TODO maintenance mode with stackdriver?
-        set_maintenance_mode(self.log,instance_id)
+
+        set_maintenance_mode(instance_id)
 
         self.log.info('Terminating node at {address}'.format(address=address))
         response = self.ec2.terminate_instances(instance_ids=[instance_id])

--- a/tyr/servers/server.py
+++ b/tyr/servers/server.py
@@ -13,6 +13,8 @@ import urllib
 from boto.vpc import VPCConnection
 from paramiko.client import AutoAddPolicy, SSHClient
 from tyr.policies import policies
+from tyr.utilities.stackdriver import (set_maintenance_mode,
+                                       unset_maintenance_mode)
 
 
 class Server(object):
@@ -875,6 +877,8 @@ named {name}""".format(path=d['path'], name=d['name']))
 
         self.log.info('The instance ID is {id_}'.format(id_=instance_id))
         #TODO maintenance mode with stackdriver?
+        set_maintenance_mode(self.log,instance_id)
+
         self.log.info('Terminating node at {address}'.format(address=address))
         response = self.ec2.terminate_instances(instance_ids=[instance_id])
 

--- a/tyr/servers/server.py
+++ b/tyr/servers/server.py
@@ -898,10 +898,10 @@ named {name}""".format(path=d['path'], name=d['name']))
 
         if instance_id in terminated:
             self.log.info('Successfully terminated {instance}'.format(
-                                                        instance=instance_id))
+                            instance=instance_id))
         else:
             self.log.info('Failed to terminate {instance}'.format(
-                                                    instance=instance_id))
+                            instance=instance_id))
 
     def bake(self):
 

--- a/tyr/servers/server.py
+++ b/tyr/servers/server.py
@@ -3,7 +3,7 @@ import boto.ec2
 import boto.route53
 import boto.ec2.networkinterface
 import logging
-import os.path
+import os
 import chef
 import time
 from boto.ec2.networkinterface import NetworkInterfaceSpecification
@@ -13,6 +13,7 @@ import urllib
 from boto.vpc import VPCConnection
 from paramiko.client import AutoAddPolicy, SSHClient
 from tyr.policies import policies
+from tyr.utilities.replace_mongo_server import stop_decommissioned_node
 
 
 class Server(object):
@@ -24,6 +25,8 @@ class Server(object):
     IAM_ROLE_POLICIES = []
 
     CHEF_RUNLIST = ['role[RoleBase]']
+    STACKDRIVER_API_KEY  = os.environ.get('STACKDRIVER_API_KEY', False)
+    STACKDRIVER_USERNAME = os.environ.get('STACKDRIVER_USERNAME', False)
 
     def __init__(self, group=None, server_type=None, instance_type=None,
                  environment=None, ami=None, region=None, role=None,
@@ -862,6 +865,16 @@ named {name}""".format(path=d['path'], name=d['name']))
                 pass
 
             return state
+
+    def terminate(self):
+        """
+        Terminate a node from AWS
+        """
+
+        address = self.instance.private_ip_address
+        stop_decommissioned_node(address=address,terminate=True,
+                                 stackdriver_username=self.STACKDRIVER_USERNAME,
+                                 stackdriver_api_key=self.STACKDRIVER_API_KEY)
 
     def bake(self):
 

--- a/tyr/servers/server.py
+++ b/tyr/servers/server.py
@@ -13,8 +13,7 @@ import urllib
 from boto.vpc import VPCConnection
 from paramiko.client import AutoAddPolicy, SSHClient
 from tyr.policies import policies
-from tyr.utilities.stackdriver import (set_maintenance_mode,
-                                       unset_maintenance_mode)
+from tyr.utilities.stackdriver import set_maintenance_mode
 
 
 class Server(object):
@@ -26,8 +25,6 @@ class Server(object):
     IAM_ROLE_POLICIES = []
 
     CHEF_RUNLIST = ['role[RoleBase]']
-    STACKDRIVER_API_KEY  = os.environ.get('STACKDRIVER_API_KEY', False)
-    STACKDRIVER_USERNAME = os.environ.get('STACKDRIVER_USERNAME', False)
 
     def __init__(self, group=None, server_type=None, instance_type=None,
                  environment=None, ami=None, region=None, role=None,


### PR DESCRIPTION
The goal is to allow for a quick rebuild of a Postfix master server.  Below is the basic overview:

- Uses a newly created chef cookbook 'role_postfix_master' to perform the postfix master server configuration.
- Relies on an existing EIP that is in DNS for the mail server's name.  The EIP must also be in the EC2-VPC for this to work properly.  
- You would supply the mail server name when building.

```python
>>> node = PostfixMaster(group='monolith',mail_name='mail11',security_groups=['p-postfix','management','chef-nodes'],chef_path='~/hudl_work/hudl-chef-repo/.chef',subnet_id='subnet-391c9f12')
>>> node.autorun()
```

- After Tyr finishes with "bake()", I added functionality to associate the EIP to the new instance.