### PR TITLE
Create a separate stackdriver module.

### DIFF
--- a/tyr/utilities/compact_mongo_collection.py
+++ b/tyr/utilities/compact_mongo_collection.py
@@ -143,19 +143,6 @@ def id_for_host(host):
 
 @timeit
 def compact_mongodb_server(host, version, prompt_before_failover=True):
-    stackdriver_api_key = os.environ.get('STACKDRIVER_API_KEY', False)
-
-    if not stackdriver_api_key:
-        log.critical('The environment variable STACKDRIVER_API_KEY '
-                     'is undefined')
-        sys.exit(1)
-
-    stackdriver_username = os.environ.get('STACKDRIVER_USERNAME', False)
-
-    if not stackdriver_username:
-        log.critical('The environment variable STACKDRIVER_USERNAME '
-                     'is undefined')
-        sys.exit(1)
 
     log.debug('Retrieving replica set for host {host}'.format(host=host))
     replica_set = ReplicaSet(host)

--- a/tyr/utilities/compact_mongo_collection.py
+++ b/tyr/utilities/compact_mongo_collection.py
@@ -1,7 +1,8 @@
 from tyr.utilities.replace_mongo_server import (ReplicaSet, run_command,
                                                 run_mongo_command, timeit)
 
-from tyr.utilities.stackdriver import set_maintenance_mode, unset_maintenance_mode
+from tyr.utilities.stackdriver import (set_maintenance_mode,
+                                       unset_maintenance_mode)
 import time
 import logging
 import os

--- a/tyr/utilities/compact_mongo_collection.py
+++ b/tyr/utilities/compact_mongo_collection.py
@@ -168,7 +168,7 @@ def compact_mongodb_server(host, version, prompt_before_failover=True):
         fetch_script(address, version)
 
         log.debug('Setting maintenance mode for {host}'.format(host=address))
-        set_maintenance_mode(log, id_for_host(address))
+        set_maintenance_mode(id_for_host(address))
 
         log.info('Compacting {host}'.format(host=address))
         compact(address)
@@ -181,7 +181,7 @@ def compact_mongodb_server(host, version, prompt_before_failover=True):
 
         log.debug('Unsetting maintenance mode for {host}'.format(
             host=address))
-        unset_maintenance_mode(log, id_for_host(address))
+        unset_maintenance_mode(id_for_host(address))
 
     log.debug('Retrieving current primary')
     secondaries = [node for node in replica_set.status['members']
@@ -213,7 +213,7 @@ def compact_mongodb_server(host, version, prompt_before_failover=True):
         fetch_script(address, version)
 
         log.debug('Setting maintenance mode for {host}'.format(host=address))
-        set_maintenance_mode(log, id_for_host(address))
+        set_maintenance_mode(id_for_host(address))
 
         log.info('Compacting {host}'.format(host=address))
         compact(address)
@@ -226,4 +226,4 @@ def compact_mongodb_server(host, version, prompt_before_failover=True):
 
         log.debug('Unsetting maintenance mode for {host}'.format(
             host=address))
-        unset_maintenance_mode(log, id_for_host(address))
+        unset_maintenance_mode(id_for_host(address))

--- a/tyr/utilities/compact_mongo_collection.py
+++ b/tyr/utilities/compact_mongo_collection.py
@@ -1,7 +1,7 @@
 from tyr.utilities.replace_mongo_server import (ReplicaSet, run_command,
                                                 run_mongo_command, timeit)
 
-import tyr.utilities.stackdriver
+from tyr.utilities.stackdriver import set_maintenance_mode, unset_maintenance_mode
 import time
 import logging
 import os

--- a/tyr/utilities/compact_mongo_collection.py
+++ b/tyr/utilities/compact_mongo_collection.py
@@ -1,7 +1,7 @@
 from tyr.utilities.replace_mongo_server import (ReplicaSet, run_command,
-                                                run_mongo_command, timeit,
-                                                set_maintenance_mode,
-                                                unset_maintenance_mode)
+                                                run_mongo_command, timeit)
+
+import tyr.utilities.stackdriver
 import time
 import logging
 import os
@@ -180,8 +180,7 @@ def compact_mongodb_server(host, version, prompt_before_failover=True):
         fetch_script(address, version)
 
         log.debug('Setting maintenance mode for {host}'.format(host=address))
-        set_maintenance_mode(stackdriver_username, stackdriver_api_key,
-                             id_for_host(address))
+        set_maintenance_mode(log, id_for_host(address))
 
         log.info('Compacting {host}'.format(host=address))
         compact(address)
@@ -194,8 +193,7 @@ def compact_mongodb_server(host, version, prompt_before_failover=True):
 
         log.debug('Unsetting maintenance mode for {host}'.format(
             host=address))
-        unset_maintenance_mode(stackdriver_username, stackdriver_api_key,
-                               id_for_host(address))
+        unset_maintenance_mode(log, id_for_host(address))
 
     log.debug('Retrieving current primary')
     secondaries = [node for node in replica_set.status['members']
@@ -227,8 +225,7 @@ def compact_mongodb_server(host, version, prompt_before_failover=True):
         fetch_script(address, version)
 
         log.debug('Setting maintenance mode for {host}'.format(host=address))
-        set_maintenance_mode(stackdriver_username, stackdriver_api_key,
-                             id_for_host(address))
+        set_maintenance_mode(log, id_for_host(address))
 
         log.info('Compacting {host}'.format(host=address))
         compact(address)
@@ -241,5 +238,4 @@ def compact_mongodb_server(host, version, prompt_before_failover=True):
 
         log.debug('Unsetting maintenance mode for {host}'.format(
             host=address))
-        unset_maintenance_mode(stackdriver_username, stackdriver_api_key,
-                               id_for_host(address))
+        unset_maintenance_mode(log, id_for_host(address))

--- a/tyr/utilities/replace_mongo_server.py
+++ b/tyr/utilities/replace_mongo_server.py
@@ -9,7 +9,8 @@ import requests
 import boto.ec2
 import boto.route53
 import logging
-from tyr.utilities.stackdriver import set_maintenance_mode, unset_maintenance_mode
+from tyr.utilities.stackdriver import (set_maintenance_mode,
+                                       unset_maintenance_mode)
 
 
 def timeit(method):

--- a/tyr/utilities/replace_mongo_server.py
+++ b/tyr/utilities/replace_mongo_server.py
@@ -9,7 +9,7 @@ import requests
 import boto.ec2
 import boto.route53
 import logging
-import tyr.utilities.stackdriver
+from tyr.utilities.stackdriver import set_maintenance_mode, unset_maintenance_mode
 
 
 def timeit(method):

--- a/tyr/utilities/replace_mongo_server.py
+++ b/tyr/utilities/replace_mongo_server.py
@@ -9,6 +9,7 @@ import requests
 import boto.ec2
 import boto.route53
 import logging
+import tyr.utilities.stackdriver
 
 
 def timeit(method):
@@ -339,134 +340,6 @@ def launch_server(environment, group, subnet_id, instance_type,
         log.critical('chef-client failed to finish running')
         sys.exit(1)
 
-
-@timeit
-def registered_in_stackdriver(stackdriver_username, stackdriver_api_key,
-                              instance_id):
-
-    log.debug('Checking if {instance_id} is listed in Stackdriver'.format(
-                                                    instance_id=instance_id))
-
-    headers = headers = {
-        'x-stackdriver-apikey': stackdriver_api_key,
-        'Content-Type': 'application/json'
-    }
-
-    log.debug('Using the headers {headers}'.format(headers=headers))
-
-    template = 'https://api.stackdriver.com/v0.2/instances/{id_}'
-
-    endpoint = template.format(id_=instance_id)
-
-    log.debug('Using the endpoint {endpoint}'.format(endpoint=endpoint))
-
-    r = requests.get(endpoint, headers=headers)
-
-    log.debug('Received status code {code}'.format(code=r.status_code))
-
-    listed = (r.status_code != 404)
-
-    if listed:
-        log.debug('The instance is listed in Stackdriver')
-    else:
-        log.debug('The instance is not listed in Stackdriver')
-
-    return listed
-
-
-@timeit
-def set_maintenance_mode(stackdriver_username, stackdriver_api_key,
-                         instance_id):
-
-    log.debug('Placing {instance_id} into maintenance mode'.format(
-                                                    instance_id=instance_id))
-
-    while not registered_in_stackdriver(stackdriver_username,
-                                        stackdriver_api_key, instance_id):
-
-        log.error('The instance is not listed in Stackdriver')
-        log.debug('Trying again in 10 seconds')
-        time.sleep(10)
-
-    headers = {
-        'x-stackdriver-apikey': stackdriver_api_key,
-        'Content-Type': 'application/json'
-    }
-
-    log.debug('Using the headers {headers}'.format(headers=headers))
-
-    template = 'https://api.stackdriver.com/v0.2/instances/{id_}/maintenance/'
-    endpoint = template.format(id_=instance_id)
-
-    log.debug('Using the endpoint {endpoint}'.format(endpoint=endpoint))
-
-    body = {
-        'username': stackdriver_username,
-        'reason': "Waiting for MongoDB node to finish syncing.",
-        'maintenance': True
-    }
-
-    log.debug('Using the body {body}'.format(body=body))
-
-    data = json.dumps(body)
-
-    r = requests.put(endpoint, data=data, headers=headers)
-
-    log.debug('Received status code {code}'.format(code=r.status_code))
-
-    if r.status_code != 200:
-        log.critical('Failed to put the node into maintenance mode. '
-                     'Received code {code}'.format(code=r.status_code))
-        sys.exit(1)
-
-    else:
-        log.debug('Placed the node into maintenance mode')
-
-
-@timeit
-def unset_maintenance_mode(stackdriver_username, stackdriver_api_key,
-                           instance_id):
-
-    log.debug('Removing {instance_id} from maintenance mode'.format(
-                                                    instance_id=instance_id))
-
-    headers = {
-        'x-stackdriver-apikey': stackdriver_api_key,
-        'Content-Type': 'application/json'
-    }
-
-    log.debug('Using the headers {headers}'.format(headers=headers))
-
-    template = 'https://api.stackdriver.com/v0.2/instances/{id_}/maintenance/'
-    endpoint = template.format(id_=instance_id)
-
-    log.debug('Using the endpoint {endpoint}'.format(endpoint=endpoint))
-
-    body = {
-        'username': stackdriver_username,
-        'reason': "MongoDB node finished syncing.",
-        'maintenance': False
-    }
-
-    log.debug('Using the body {body}'.format(body=body))
-
-    data = json.dumps(body)
-
-    r = requests.put(endpoint, data=data, headers=headers)
-
-    log.debug('Received status code {code}'.format(code=r.status_code))
-
-    if r.status_code != 200:
-
-        log.critical('Failed to remove the node from maintenance mode. '
-                     'Received code {code}'.format(code=r.status_code))
-        sys.exit(1)
-
-    else:
-
-        log.debug('Removed the node from maintenance mode.')
-
-
 @timeit
 def wait_for_sync(node):
 
@@ -507,9 +380,7 @@ def wait_for_sync(node):
 
 
 @timeit
-def stop_decommissioned_node(address, terminate=False,
-                             stackdriver_username=None,
-                             stackdriver_api_key=None):
+def stop_decommissioned_node(address, terminate=False):
 
     log.debug('Stopping or terminating the node at {address}'.format(
                                                         address=address))
@@ -520,8 +391,7 @@ def stop_decommissioned_node(address, terminate=False,
 
     log.debug('The instance ID is {id_}'.format(id_=instance_id))
 
-    set_maintenance_mode(stackdriver_username, stackdriver_api_key,
-                         instance_id)
+    set_maintenance_mode(log, instance_id)
 
     log.debug('Establishing a connection to AWS EC2 us-east-1')
     conn = boto.ec2.connect_to_region('us-east-1')
@@ -551,7 +421,6 @@ def stop_decommissioned_node(address, terminate=False,
         else:
             log.debug('Failed to stop {instance}'.format(
                                                         instance=instance_id))
-
 
 @timeit
 def replace_server(environment=None, group=None, subnet_id=None,
@@ -705,8 +574,7 @@ def replace_server(environment=None, group=None, subnet_id=None,
                          replica_set_template=replica_set_name)
 
     log.info('Placing the new node in maintenance mode')
-    set_maintenance_mode(stackdriver_username, stackdriver_api_key,
-                         node.instance.id)
+    set_maintenance_mode(log, node.instance.id)
 
     log.info('Adding the new node to the replica set')
 
@@ -731,8 +599,7 @@ def replace_server(environment=None, group=None, subnet_id=None,
     wait_for_sync(node)
 
     log.info('Removing the node from maintenance mode')
-    unset_maintenance_mode(stackdriver_username, stackdriver_api_key,
-                           node.instance.id)
+    unset_maintenance_mode(log, node.instance.id)
 
     if arbiter is not None:
         log.info('Adding the arbiter back into the replica set')

--- a/tyr/utilities/replace_mongo_server.py
+++ b/tyr/utilities/replace_mongo_server.py
@@ -436,22 +436,6 @@ def replace_server(environment=None, group=None, subnet_id=None,
         log.critical('No existing member defined.')
         sys.exit(1)
 
-    stackdriver_api_key = os.environ.get('STACKDRIVER_API_KEY', False)
-
-    if not stackdriver_api_key:
-
-        log.critical('The environment variable STACKDRIVER_API_KEY '
-                     'is undefined')
-        sys.exit(1)
-
-    stackdriver_username = os.environ.get('STACKDRIVER_USERNAME', False)
-
-    if not stackdriver_username:
-
-        log.critical('The environment variable STACKDRIVER_USERNAME '
-                     'is undefined')
-        sys.exit(1)
-
     replica_set = ReplicaSet(member)
 
     if replica_set.primary[:2] == 'ip':
@@ -558,9 +542,7 @@ def replace_server(environment=None, group=None, subnet_id=None,
 
         if replace:
             log.info('Terminating the previous arbiter')
-            stop_decommissioned_node(member, terminate=terminate,
-                                     stackdriver_username=stackdriver_username,
-                                     stackdriver_api_key=stackdriver_api_key)
+            stop_decommissioned_node(member, terminate=terminate)
 
         return
 
@@ -625,9 +607,7 @@ def replace_server(environment=None, group=None, subnet_id=None,
         replica_set.remove_member(member)
 
         log.info('Terminating the previous node')
-        stop_decommissioned_node(member, terminate=terminate,
-                                 stackdriver_username=stackdriver_username,
-                                 stackdriver_api_key=stackdriver_api_key)
+        stop_decommissioned_node(member, terminate=terminate)
 
         if node_type == 'data' and reroute:
             log.info('Redirecting previous DNS entry')

--- a/tyr/utilities/replace_mongo_server.py
+++ b/tyr/utilities/replace_mongo_server.py
@@ -392,7 +392,7 @@ def stop_decommissioned_node(address, terminate=False):
 
     log.debug('The instance ID is {id_}'.format(id_=instance_id))
 
-    set_maintenance_mode(log, instance_id)
+    set_maintenance_mode(instance_id)
 
     log.debug('Establishing a connection to AWS EC2 us-east-1')
     conn = boto.ec2.connect_to_region('us-east-1')
@@ -557,7 +557,7 @@ def replace_server(environment=None, group=None, subnet_id=None,
                          replica_set_template=replica_set_name)
 
     log.info('Placing the new node in maintenance mode')
-    set_maintenance_mode(log, node.instance.id)
+    set_maintenance_mode(node.instance.id)
 
     log.info('Adding the new node to the replica set')
 
@@ -582,7 +582,7 @@ def replace_server(environment=None, group=None, subnet_id=None,
     wait_for_sync(node)
 
     log.info('Removing the node from maintenance mode')
-    unset_maintenance_mode(log, node.instance.id)
+    unset_maintenance_mode(node.instance.id)
 
     if arbiter is not None:
         log.info('Adding the arbiter back into the replica set')

--- a/tyr/utilities/stackdriver.py
+++ b/tyr/utilities/stackdriver.py
@@ -2,9 +2,33 @@ import requests
 import os
 import json
 import time
+import logging
+
+local_log = logging.getLogger('Tyr.Utilities.Stackdriver')
+if not local_log.handlers:
+    local_log.setLevel(logging.DEBUG)
+    ch = logging.StreamHandler()
+    ch.setLevel(logging.DEBUG)
+    formatter = logging.Formatter(
+            '%(asctime)s [%(name)s] %(levelname)s: %(message)s',
+            datefmt='%H:%M:%S')
+    ch.setFormatter(formatter)
+    local_log.addHandler(ch)
 
 STACKDRIVER_USERNAME = os.environ.get('STACKDRIVER_USERNAME',False)
+
+if not STACKDRIVER_USERNAME:
+    local_log.critical('The environment variable STACKDRIVER_USERNAME '
+                    'is undefined')
+    sys.exit(1)
+
 STACKDRIVER_API_KEY  = os.environ.get('STACKDRIVER_API_KEY',False)
+
+if not STACKDRIVER_API_KEY:
+    local_log.critical('The environment variable STACKDRIVER_API_KEY '
+                    'is undefined')
+    sys.exit(1)
+
 
 def registered_in_stackdriver(log,instance_id):
 

--- a/tyr/utilities/stackdriver.py
+++ b/tyr/utilities/stackdriver.py
@@ -4,33 +4,33 @@ import json
 import time
 import logging
 
-local_log = logging.getLogger('Tyr.Utilities.Stackdriver')
-if not local_log.handlers:
-    local_log.setLevel(logging.DEBUG)
+log = logging.getLogger('Tyr.Utilities.Stackdriver')
+if not log.handlers:
+    log.setLevel(logging.DEBUG)
     ch = logging.StreamHandler()
     ch.setLevel(logging.DEBUG)
     formatter = logging.Formatter(
             '%(asctime)s [%(name)s] %(levelname)s: %(message)s',
             datefmt='%H:%M:%S')
     ch.setFormatter(formatter)
-    local_log.addHandler(ch)
+    log.addHandler(ch)
 
 STACKDRIVER_USERNAME = os.environ.get('STACKDRIVER_USERNAME',False)
 
 if not STACKDRIVER_USERNAME:
-    local_log.critical('The environment variable STACKDRIVER_USERNAME '
+    log.critical('The environment variable STACKDRIVER_USERNAME '
                     'is undefined')
     sys.exit(1)
 
 STACKDRIVER_API_KEY  = os.environ.get('STACKDRIVER_API_KEY',False)
 
 if not STACKDRIVER_API_KEY:
-    local_log.critical('The environment variable STACKDRIVER_API_KEY '
+    log.critical('The environment variable STACKDRIVER_API_KEY '
                     'is undefined')
     sys.exit(1)
 
 
-def registered_in_stackdriver(log,instance_id):
+def registered_in_stackdriver(instance_id):
 
     log.debug('Checking if {instance_id} is listed in Stackdriver'.format(
                                                     instance_id=instance_id))
@@ -61,7 +61,7 @@ def registered_in_stackdriver(log,instance_id):
 
     return listed
 
-def set_maintenance_mode(log,instance_id):
+def set_maintenance_mode(instance_id):
 
     log.debug('Placing {instance_id} into maintenance mode'.format(
                                                     instance_id=instance_id))
@@ -106,7 +106,7 @@ def set_maintenance_mode(log,instance_id):
     else:
         log.debug('Placed the node into maintenance mode')
 
-def unset_maintenance_mode(log,instance_id):
+def unset_maintenance_mode(instance_id):
 
     log.debug('Removing {instance_id} from maintenance mode'.format(
                                                     instance_id=instance_id))


### PR DESCRIPTION
  - Pull all of the stackdriver related functions out of the
    replace_mongo_server package and move it into its own module.
  - These functions will now accept a log object and instance ID
  - Adjust calls to these functions to reflect the changes made.