### PR TITLE
Missing import in stackdriver module

### DIFF
--- a/tyr/utilities/stackdriver.py
+++ b/tyr/utilities/stackdriver.py
@@ -3,6 +3,7 @@ import os
 import json
 import time
 import logging
+import sys
 
 log = logging.getLogger('Tyr.Utilities.Stackdriver')
 if not log.handlers:


### PR DESCRIPTION
Simple fix of a missing import.

Related Q: because the stackdriver utilities module gets imported into `tyr.servers.server.py`, Tyr won't work if you don't have the Stackdriver environment variables set. Is this desired?
