### PR TITLE
Add configurable values for mongo data node EBS volumes.

### DIFF
--- a/tyr/servers/mongo/data.py
+++ b/tyr/servers/mongo/data.py
@@ -36,50 +36,50 @@ class MongoDataNode(MongoReplicaSetMember):
         self.log_volume_iops = log_volume_iops
 
     def validate_ebs_volume(self, volume_type):
-        eval_volume_size = 0
-        eval_volume_iops = 0
+        volume_size = 0
+        volume_iops = 0
 
         if volume_type == 'data':
-            eval_volume_size = self.data_volume_size
-            eval_volume_iops = self.data_volume_iops
+            volume_size = self.data_volume_size
+            volume_iops = self.data_volume_iops
         elif volume_type == 'journal':
-            eval_volume_size = self.journal_volume_size
-            eval_volume_iops = self.journal_volume_iops
+            volume_size = self.journal_volume_size
+            volume_iops = self.journal_volume_iops
         elif volume_type == 'log':
-            eval_volume_size = self.log_volume_size
-            eval_volume_iops = self.log_volume_iops
+            volume_size = self.log_volume_size
+            volume_iops = self.log_volume_iops
         else:
             msg = 'Unable to validate drive type: {volume_type}'.format(
                 volume_type=volume_type)
             self.log.critical(msg)
             sys.exit(1)
 
-        if eval_volume_size is None:
+        if volume_size is None:
             msg = 'No {volume_type} volume size provided'.format(
                 volume_type=volume_type)
             self.log.warn(msg)
-            eval_volume_size = self.set_default_volume_size(volume_type)
-        elif eval_volume_size < 1:
+            volume_size = self.set_default_volume_size(volume_type)
+        elif volume_size < 1:
             self.log.critical('The {volume_type} volume size is less than 1'.
                               format(volume_type=volume_type))
             sys.exit(1)
 
         msg = 'Using {volume_type} volume size "{size}"'.format(
-            volume_type=volume_type, size=eval_volume_size)
+            volume_type=volume_type, size=volume_size)
         self.log.info(msg)
 
-        if eval_volume_iops is None:
+        if volume_iops is None:
             msg = 'No {volume_type} volume iops provided'.format(
                 volume_type=volume_type)
             self.log.warn(msg)
 
-            eval_volume_iops = self.set_default_volume_iops(volume_type)
+            volume_iops = self.set_default_volume_iops(volume_type)
 
         msg = 'Using {volume_type} volume iops "{iops}"'.format(
-            volume_type=volume_type, iops=eval_volume_iops)
+            volume_type=volume_type, iops=volume_iops)
         self.log.info(msg)
 
-        iops_size_ratio = eval_volume_iops/eval_volume_size
+        iops_size_ratio = volume_iops/volume_size
 
         self.log.info('The IOPS to Size ratio is "{ratio}"'.format(
             ratio=iops_size_ratio))
@@ -107,21 +107,21 @@ class MongoDataNode(MongoReplicaSetMember):
                 self.data_volume_iops = 3000
             else:
                 self.data_volume_iops = 0
-            size = self.data_volume_iops
+            default_volume_iops = self.data_volume_iops
         elif volume_type == 'journal':
             if self.environment == 'prod':
                 self.journal_volume_iops = 500
             else:
                 self.journal_volume_iops = 0
-            size = self.journal_volume_iops
+            default_volume_iops = self.journal_volume_iops
         elif volume_type == 'log':
             if self.environment == 'prod':
                 self.log_volume_iops = 200
             else:
                 self.log_volume_iops = 0
-            size = self.log_volume_iops
+            default_volume_iops = self.log_volume_iops
 
-        return size
+        return default_volume_iops
 
     def configure(self):
 

--- a/tyr/servers/mongo/data.py
+++ b/tyr/servers/mongo/data.py
@@ -17,7 +17,9 @@ class MongoDataNode(MongoReplicaSetMember):
                  security_groups=None, block_devices=None,
                  chef_path=None, subnet_id=None, dns_zones=None,
                  replica_set=None, data_volume_size=None,
-                 data_volume_iops=None, mongodb_version=None):
+                 data_volume_iops=None, journal_volume_size=None,
+                 journal_volume_iops=None, log_volume_size=None,
+                 log_volume_iops=None, mongodb_version=None):
 
         super(MongoDataNode, self).__init__(group, server_type, instance_type,
                                             environment, ami, region, role,
@@ -28,6 +30,10 @@ class MongoDataNode(MongoReplicaSetMember):
 
         self.data_volume_size = data_volume_size
         self.data_volume_iops = data_volume_iops
+        self.journal_volume_size = journal_volume_size
+        self.journal_volume_iops = journal_volume_iops
+        self.log_volume_size = log_volume_size
+        self.log_volume_iops = log_volume_iops
 
     def configure(self):
 
@@ -85,16 +91,16 @@ class MongoDataNode(MongoReplicaSetMember):
                 {
                     'user': 'mongod',
                     'group': 'mongod',
-                    'size': 25,
-                    'iops': 250,
+                    'size': self.journal_volume_size,
+                    'iops': self.journal_volume_iops,
                     'device': '/dev/xvdg',
                     'mount': '/volr/journal'
                 },
                 {
                     'user': 'mongod',
                     'group': 'mongod',
-                    'size': 50,
-                    'iops': 250,
+                    'size': self.log_volume_size,
+                    'iops': self.log_volume_iops,
                     'device': '/dev/xvdh',
                     'mount': '/mongologs',
                 }

--- a/tyr/servers/mongo/data.py
+++ b/tyr/servers/mongo/data.py
@@ -35,8 +35,10 @@ class MongoDataNode(MongoReplicaSetMember):
         self.log_volume_size = log_volume_size
         self.log_volume_iops = log_volume_iops
 
-
     def validate_ebs_volume(self, volume_type):
+        eval_volume_size = 0
+        eval_volume_iops = 0
+
         if volume_type == 'data':
             eval_volume_size = self.data_volume_size
             eval_volume_iops = self.data_volume_iops
@@ -53,36 +55,38 @@ class MongoDataNode(MongoReplicaSetMember):
             sys.exit(1)
 
         if eval_volume_size is None:
-            self.log.warn('No {volume_type} volume size provided'.format(
-            volume_type=volume_type))
-            eval_volume_size = set_default_volume_size(volume_type)
-        elif self.eval_volume_size < 1:
+            msg = 'No {volume_type} volume size provided'.format(
+                volume_type=volume_type)
+            self.log.warn(msg)
+            eval_volume_size = self.set_default_volume_size(volume_type)
+        elif eval_volume_size < 1:
             self.log.critical('The {volume_type} volume size is less than 1'.
                               format(volume_type=volume_type))
             sys.exit(1)
 
-        self.log.info('Using {volume_type} volume size "{size}"'.format(
-                                            volume_type=volume_type,
-                                            size=eval_volume_size))
+        msg = 'Using {volume_type} volume size "{size}"'.format(
+            volume_type=volume_type, size=eval_volume_size)
+        self.log.info(msg)
 
         if eval_volume_iops is None:
-            self.log.warn('No {volume_type} volume iops provided'.format(
-            volume_type=volume_type))
-            eval_volume_iops = set_default_volume_iops(volume_type)
+            msg = 'No {volume_type} volume iops provided'.format(
+                volume_type=volume_type)
+            self.log.warn(msg)
 
-        self.log.info('Using {volume_type} volume iops "{iops}"'.format(
-                                            volume_type=volume_type,
-                                            iops=eval_volume_iops))
+            eval_volume_iops = self.set_default_volume_iops(volume_type)
+
+        msg = 'Using {volume_type} volume iops "{iops}"'.format(
+            volume_type=volume_type, iops=eval_volume_iops)
+        self.log.info(msg)
 
         iops_size_ratio = eval_volume_iops/eval_volume_size
 
         self.log.info('The IOPS to Size ratio is "{ratio}"'.format(
-                                            ratio=iops_size_ratio))
+            ratio=iops_size_ratio))
 
         if iops_size_ratio > 30:
             self.log.critical('The IOPS to Size ratio is greater than 30')
             sys.exit(1)
-
 
     def set_default_volume_size(self, volume_type):
         if volume_type == 'data':
@@ -96,7 +100,6 @@ class MongoDataNode(MongoReplicaSetMember):
             size = 10
 
         return size
-
 
     def set_default_volume_iops(self, volume_type):
         if volume_type == 'data':
@@ -120,7 +123,6 @@ class MongoDataNode(MongoReplicaSetMember):
 
         return size
 
-
     def configure(self):
 
         super(MongoDataNode, self).configure()
@@ -133,7 +135,6 @@ class MongoDataNode(MongoReplicaSetMember):
         self.validate_ebs_volume('data')
         self.validate_ebs_volume('journal')
         self.validate_ebs_volume('log')
-
 
     def bake(self):
 


### PR DESCRIPTION
  - Both the journal and log EBS data volumes had static values for size
    and iops, which becomes problematic when dealing with multiverse
    mongo instances as they vary quite a bit.
  - Add capability to pass in the above values.