### PR TITLE
Re-Determine the Replica Set Primary After a Replacement Node Finishes Syncing

### DIFF
--- a/tyr/utilities/replace_mongo_server.py
+++ b/tyr/utilities/replace_mongo_server.py
@@ -603,8 +603,6 @@ def replace_server(environment=None, group=None, subnet_id=None,
 
     if replace:
 
-        replica_set.determine_primary(member)
-
         log.info('Preparing to remove the previous node')
 
         if prompt_before_replace:

--- a/tyr/utilities/replace_mongo_server.py
+++ b/tyr/utilities/replace_mongo_server.py
@@ -603,14 +603,14 @@ def replace_server(environment=None, group=None, subnet_id=None,
 
     if replace:
 
-        replica_set.determine_primary(member)
-
         log.info('Preparing to remove the previous node')
 
         if prompt_before_replace:
 
             print '\a'
             _ = raw_input('Press enter to continue')
+
+        replica_set.determine_primary(member)
 
         if replica_set.primary == member:
 

--- a/tyr/utilities/replace_mongo_server.py
+++ b/tyr/utilities/replace_mongo_server.py
@@ -603,6 +603,8 @@ def replace_server(environment=None, group=None, subnet_id=None,
 
     if replace:
 
+        replica_set.determine_primary(member)
+
         log.info('Preparing to remove the previous node')
 
         if prompt_before_replace:


### PR DESCRIPTION
After a MongoDB replacement node finishes syncing, re-determine the replica set's primary in case it has changed since the sync started.