### PR TITLE
Only Enabled EBS Optimization on MongoDB Nodes in Prod

### DIFF
--- a/tyr/servers/mongo/node.py
+++ b/tyr/servers/mongo/node.py
@@ -32,7 +32,9 @@ class MongoNode(Server):
     def configure(self):
 
         super(MongoNode, self).configure()
-        self.ebs_optimized = True
+
+        if self.environment == 'prod':
+            self.ebs_optimized = True
 
         if self.environment == "prod":
             self.IAM_ROLE_POLICIES.append('allow-mongo-backup-snapshot')


### PR DESCRIPTION
Fixes #84 

> in /tyr/servers/mongo/node.py, self.ebs_optimized = True, should only be set for nodes where self.environment == "prod"

> Currently you cannot provision a non ebs-optimized server in stage or test.