### PR TITLE
Further fix for INF-952 permissions

### DIFF
--- a/tyr/policies/ec2.py
+++ b/tyr/policies/ec2.py
@@ -225,6 +225,16 @@ allow_outpost_sns_test = """{
       "Resource": [
         "arn:aws:sns:us-east-1:761584570493:*"
       ]
+    },
+    {
+      "Sid": "Stmt1442579118000",
+      "Effect": "Allow",
+      "Action": [
+          "autoscaling:CompleteLifecycleAction"
+      ],
+      "Resource": [
+          "*"
+      ]
     }
   ]
 }"""
@@ -257,40 +267,60 @@ allow_outpost_sns_prod = """{
       "Resource": [
         "arn:aws:sns:us-east-1:761584570493:*"
       ]
+    },
+    {
+      "Sid": "Stmt1442579118000",
+      "Effect": "Allow",
+      "Action": [
+          "autoscaling:CompleteLifecycleAction"
+      ],
+      "Resource": [
+          "*"
+      ]
     }
   ]
 }"""
 
 allow_outpost_sns_stage = """{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "Stmt1390578067000",
-      "Effect": "Allow",
-      "Action": [
-        "sns:ListSubscriptions",
-        "sns:ListSubscriptionsByTopic",
-        "sns:Publish",
-        "sns:Subscribe"
-      ],
-      "Resource": [
-        "arn:aws:sns:us-east-1:761584570493:alyx3",
-        "arn:aws:sns:us-east-1:761584570493:stage-config-changes",
-        "arn:aws:sns:us-east-1:761584570493:s-outpost"
-      ]
-    },
-    {
-      "Sid": "Stmt1390578067001",
-      "Effect": "Allow",
-      "Action": [
-        "sns:ConfirmSubscription",
-        "sns:Unsubscribe"
-      ],
-      "Resource": [
-        "arn:aws:sns:us-east-1:761584570493:*"
-      ]
-    }
-  ]
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "Stmt1390578067000",
+            "Effect": "Allow",
+            "Action": [
+                "sns:ListSubscriptions",
+                "sns:ListSubscriptionsByTopic",
+                "sns:Publish",
+                "sns:Subscribe"
+            ],
+            "Resource": [
+                "arn:aws:sns:us-east-1:761584570493:alyx3",
+                "arn:aws:sns:us-east-1:761584570493:stage-config-changes",
+                "arn:aws:sns:us-east-1:761584570493:s-outpost"
+            ]
+        },
+        {
+            "Sid": "Stmt1390578067001",
+            "Effect": "Allow",
+            "Action": [
+                "sns:ConfirmSubscription",
+                "sns:Unsubscribe"
+            ],
+            "Resource": [
+                "arn:aws:sns:us-east-1:761584570493:*"
+            ]
+        },
+        {
+            "Sid": "Stmt1442579118000",
+            "Effect": "Allow",
+            "Action": [
+                "autoscaling:CompleteLifecycleAction"
+            ],
+            "Resource": [
+                "*"
+            ]
+        }
+    ]
 }"""
 
 


### PR DESCRIPTION
This is another change to the IAM role permissions in order to allow web servers to send the autoscale lifecycle completion message.