### PR TITLE
Add mongo cm monitoring type

### DIFF
--- a/tyr/servers/mongo/cm_monitor.py
+++ b/tyr/servers/mongo/cm_monitor.py
@@ -1,0 +1,22 @@
+from tyr.servers.server import Server
+
+
+class MongoCmMonitor(Server):
+
+    SERVER_TYPE = 'mms'
+    CHEF_RUNLIST = ['role[RoleMongoCmMonitor]']
+
+    def __init__(self, group=None, server_type=None, instance_type=None,
+                 environment=None, ami=None, region=None, role=None,
+                 keypair=None, availability_zone=None,
+                 security_groups=None, block_devices=None,
+                 chef_path=None, subnet_id=None, dns_zones=None):
+
+        if server_type is None:
+            server_type = self.SERVER_TYPE
+
+        super(MongoCmMonitor, self).__init__(group, server_type, instance_type,
+                                             environment, ami, region, role,
+                                             keypair, availability_zone,
+                                             security_groups, block_devices,
+                                             chef_path, subnet_id, dns_zones)

--- a/tyr/servers/mongo/cm_monitor.py
+++ b/tyr/servers/mongo/cm_monitor.py
@@ -20,3 +20,15 @@ class MongoCmMonitor(Server):
                                              keypair, availability_zone,
                                              security_groups, block_devices,
                                              chef_path, subnet_id, dns_zones)
+
+    def configure(self):
+        super(MongoCmMonitor, self).configure()
+
+        self.security_groups = [
+            'management',
+            'chef-nodes',
+            'big-spark-slaves',
+            'p-mms',
+        ]
+
+        self.resolve_security_groups()


### PR DESCRIPTION
- There was a cookbook developed for automatically configuring the
  Mongo Monitoring Agent instances in an attempt to easily move them
  to the VPC. The goal of this new Server Type is to leverage that
  cookbook and make it easy to spin up this server type in the future.
