### PR TITLE
NO-TICK: Increase ASG grace period to 900

### DIFF
--- a/tyr/clusters/autoscaling.py
+++ b/tyr/clusters/autoscaling.py
@@ -17,7 +17,7 @@ class AutoScaler(object):
                  default_cooldown=300,
                  availability_zones=None,
                  subnet_ids=None,
-                 health_check_grace_period=300):
+                 health_check_grace_period=900):
         self.log = logging.getLogger('Tyr.Clusters.AutoScaler')
         self.log.setLevel(logging.DEBUG)
 


### PR DESCRIPTION
There have been several incidents where ASG spins up an instance, it goes on the vicious cycle of `start -> status check failed -> terminate -> start -> ..` Currently a web server takes roughly 20 minutes to spin up, so increasing the grace period to 900 has so far mitigated this issue.