### PR TITLE
NO-TICK: Missing sys

### DIFF
--- a/tyr/utilities/stackdriver.py
+++ b/tyr/utilities/stackdriver.py
@@ -3,6 +3,7 @@ import os
 import json
 import time
 import logging
+import sys
 
 log = logging.getLogger('Tyr.Utilities.Stackdriver')
 if not log.handlers:


### PR DESCRIPTION
Getting `NameError: name 'sys' is not defined` on stackdriver.py.