### PR TITLE
Specifying the instance type in the launch configuration, allowing th…

### DIFF
--- a/tyr/clusters/autoscaling.py
+++ b/tyr/clusters/autoscaling.py
@@ -10,7 +10,6 @@ class AutoScaler(object):
     '''
     def __init__(self, launch_configuration,
                  autoscaling_group,
-                 instance_type,
                  node_obj,
                  desired_capacity=1,
                  max_size=1,
@@ -24,7 +23,6 @@ class AutoScaler(object):
 
         self.launch_configuration = launch_configuration
         self.autoscaling_group = autoscaling_group
-        self.instance_type = instance_type
         self.desired_capacity = desired_capacity
 
         # You can set a list of availability zones explicitly, else it will
@@ -79,7 +77,7 @@ class AutoScaler(object):
                                      get_security_group_ids(
                                          self.node_obj.security_groups),
                                      user_data=self.node_obj.user_data,
-                                     instance_type=self.instance_type,
+                                     instance_type=self.node_obj.instance_type,
                                      instance_profile_name=self.node_obj.role)
             self.conn.create_launch_configuration(lc)
             self.launch_configuration = lc

--- a/tyr/clusters/autoscaling.py
+++ b/tyr/clusters/autoscaling.py
@@ -10,6 +10,7 @@ class AutoScaler(object):
     '''
     def __init__(self, launch_configuration,
                  autoscaling_group,
+                 instance_type,
                  node_obj,
                  desired_capacity=1,
                  max_size=1,
@@ -23,6 +24,7 @@ class AutoScaler(object):
 
         self.launch_configuration = launch_configuration
         self.autoscaling_group = autoscaling_group
+        self.instance_type = instance_type
         self.desired_capacity = desired_capacity
 
         # You can set a list of availability zones explicitly, else it will
@@ -77,6 +79,7 @@ class AutoScaler(object):
                                      get_security_group_ids(
                                          self.node_obj.security_groups),
                                      user_data=self.node_obj.user_data,
+                                     instance_type=self.instance_type,
                                      instance_profile_name=self.node_obj.role)
             self.conn.create_launch_configuration(lc)
             self.launch_configuration = lc

--- a/tyr/clusters/iis.py
+++ b/tyr/clusters/iis.py
@@ -86,7 +86,6 @@ class IISCluster():
         self.log.info('Creating autoscaler')
         auto = AutoScaler(launch_configuration=self.launch_configuration,
                           autoscaling_group=self.autoscaling_group,
-                          instance_type=self.instance_type,
                           desired_capacity=self.desired_capacity,
                           max_size=self.max_size,
                           min_size=self.min_size,

--- a/tyr/clusters/iis.py
+++ b/tyr/clusters/iis.py
@@ -86,6 +86,7 @@ class IISCluster():
         self.log.info('Creating autoscaler')
         auto = AutoScaler(launch_configuration=self.launch_configuration,
                           autoscaling_group=self.autoscaling_group,
+                          instance_type=self.instance_type,
                           desired_capacity=self.desired_capacity,
                           max_size=self.max_size,
                           min_size=self.min_size,


### PR DESCRIPTION
Before, the specified `instance_type` wasn't getting respected when spinning up new servers. This was because it wasn't getting used when creating launch configurations.

This PR passes the `instance_type` down through the `Autoscaler` to the `LaunchConfiguration` constructor, which fixed a bug causing new servers spun up with Tyr to all be `m1.small`.