### PR TITLE
Support for Data Files

### DIFF
--- a/data/.placeholder
+++ b/data/.placeholder
@@ -1,0 +1,3 @@
+Just a placeholder file until something is added to the directory.
+
+So, y'know, the directory doesn't disappear from git.

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
     version='0.0.1',
     author='Mihir Singh (@citruspi)',
     author_email='mihir.singh@hudl.com',
+    test_suite='nose.collector',
     packages=['tyr'],
     zip_safe=False,
     include_package_data=True,
@@ -26,7 +27,8 @@ setup(
         'paramiko',
         'click',
         'PyYAML',
-        'requests'
+        'requests',
+        'nose'
     ],
     scripts=[
         'scripts/replace-mongodb-servers',

--- a/setup.py
+++ b/setup.py
@@ -20,5 +20,8 @@ setup(
     scripts=[
         'scripts/replace-mongodb-servers',
         'scripts/compact-mongodb-servers'
+    ],
+    data_files=[
+        # Insert data files in here as necessary
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,15 @@
 from setuptools import setup
+import os
+
+
+def load_data_files():
+    data_files = []
+
+    for root, _, files in os.walk('data'):
+        data_files.extend(['{r}/{f}'.format(r=root, f=f) for f in files])
+
+    return [('data', data_files)]
+
 
 setup(
     name='tyr',
@@ -21,7 +32,5 @@ setup(
         'scripts/replace-mongodb-servers',
         'scripts/compact-mongodb-servers'
     ],
-    data_files=[
-        # Insert data files in here as necessary
-    ]
+    data_files=load_data_files()
 )

--- a/tests/test_helpers/test_data_file.py
+++ b/tests/test_helpers/test_data_file.py
@@ -1,0 +1,32 @@
+import os
+from tyr.helpers import data_file
+
+
+def setup_successful_file():
+    root = os.path.abspath(os.path.dirname(__file__))
+    path = os.path.join(root, '..', '..', 'data', '.test_successful_file')
+
+    contents = 'Good news, everyone! Tyr has tests!'
+
+    with open(path, 'w') as f:
+        f.write(contents)
+
+
+def cleanup_successful_file():
+    root = os.path.abspath(os.path.dirname(__file__))
+    path = os.path.join(root, '..', '..', 'data', '.test_successful_file')
+
+    os.remove(path)
+
+
+def test_successful_file():
+    f = data_file('.test_successful_file')
+
+    assert type(f) == file
+
+    expected = 'Good news, everyone! Tyr has tests!'
+
+    assert f.read() == expected
+
+test_successful_file.setUp = setup_successful_file
+test_successful_file.tearDown = cleanup_successful_file

--- a/tests/test_helpers/test_data_file.py
+++ b/tests/test_helpers/test_data_file.py
@@ -1,5 +1,6 @@
 import os
 from tyr.helpers import data_file
+from nose.tools import raises
 
 
 def setup_successful_file():
@@ -30,3 +31,8 @@ def test_successful_file():
 
 test_successful_file.setUp = setup_successful_file
 test_successful_file.tearDown = cleanup_successful_file
+
+
+@raises(IOError)
+def test_missing_file():
+    f = data_file('oh-boy-i-really-hope-no-one-used-this-name-for-a-data-file')

--- a/tyr/helpers/__init__.py
+++ b/tyr/helpers/__init__.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python
+# -*- coding: utf8 -*-
+
+from tyr.helpers.data_file import data_file

--- a/tyr/helpers/data_file.py
+++ b/tyr/helpers/data_file.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+# -*- coding: utf8 -*-
+
+import os
+
+
+def data_file(path):
+    root = os.path.abspath(os.path.dirname(__file__))
+    path = os.path.join(root, '..', '..', 'data', path)
+
+    return open(path, 'r')


### PR DESCRIPTION
If we decide to use `data_files` in #96, this should make it pretty simple.

To add a data file, simply place it in the `data` directory and add it to `data_files` in `setup.py`.

The entry in `data_files` would look something like this:

``` python
('data', ['data/<file_name>'])
```

So for the data file `user_data_base.ps1`, `setup.py` might look like this:

``` python
from setuptools import setup

setup(
    ...
    platforms='any',
    data_files=[
        ('data', ['data/user_data_base.ps1'])
    ]
)
```

To access the data file `user_data_base.ps1` from within Tyr, it'd look like this:

``` python
from tyr.helpers import data_file

try:
    f = data_file('user_data_base.ps1')
    user_data = f.read()
except IOError:
    # Handle error reading file
    pass
```