### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ At this point, the only dependencies are
 
 These are specified in the `setup.py` file and will automatically be installed.
 
+Also need to set `STACKDRIVER_USERNAME` and `STACKDRIVER_API_KEY`
+
+Chef credentials are also required to be present in `~/.chef/chef-validator.pem`
+
 ## Usage
 
 Ideally, the usage of each server and cluster type should be documented.


### PR DESCRIPTION
added missing dependency on setting `STACKDRIVER_` environment variables and requirement of chef creds