### PR TITLE
Use A Records with Private IP Addresses in Place of CNAMES with Private Hostnames

### DIFF
--- a/tyr/servers/server.py
+++ b/tyr/servers/server.py
@@ -259,9 +259,9 @@ class Server(object):
                             'ttl': 60
                         },
                         {
-                            'type': 'CNAME',
+                            'type': 'A',
                             'name': '{hostname}.',
-                            'value': '{private_dns_name}',
+                            'value': '{private_ip_address}',
                             'ttl': 60
                         }
                     ]
@@ -274,9 +274,9 @@ class Server(object):
                     },
                     'records': [
                         {
-                            'type': 'CNAME',
+                            'type': 'A',
                             'name': '{hostname}.',
-                            'value': '{private_dns_name}',
+                            'value': '{private_ip_address}',
                             'ttl': 60
                         }
                     ]


### PR DESCRIPTION
**Issue**:
While provisioning MongoDB nodes for use with MongoDB Cloud Manager yesterday, @Z3r0Sum and I noticed that the nodes would come up within Cloud Manager using their private hostnames (e.g. `ip-165-23-127-185.ap-southeast-2.compute.internal`) instead of their public names (e.g. `p-dvms-mongo-rs1-use1c-01...`).

While not a huge issue, it makes it harder to find servers in Cloud Manager and will likely make future automation with the Cloud Manager API more difficult.

**Solution**:
Using `A` records with the private IP address instead of `CNAME` records with the private hostnames fixes this issue.

**Relevant GIF**:
![giphy](https://cloud.githubusercontent.com/assets/2125849/14326818/ac1f6f98-fbfd-11e5-8879-6fc425f12ed2.gif)
