### PR TITLE
Include an Additional EBS Volume for Swap on MongoDB Instances that Lack Instance Storage

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,8 @@ setup(
         'click',
         'PyYAML',
         'requests',
-        'nose'
+        'nose',
+        'cloudspecs'
     ],
     scripts=[
         'scripts/replace-mongodb-servers',

--- a/tyr/servers/mongo/arbiter.py
+++ b/tyr/servers/mongo/arbiter.py
@@ -31,7 +31,7 @@ class MongoArbiterNode(MongoReplicaSetMember):
 
         with self.chef_api:
 
-            self.chef_node.attributes.set_dotted('hudl_ebs.volumes', [
+            ebs_volumes = [
                 {
                     'user': 'mongod',
                     'group': 'mongod',
@@ -40,7 +40,22 @@ class MongoArbiterNode(MongoReplicaSetMember):
                     'device': '/dev/xvdf',
                     'mount': '/volr'
                 }
-            ])
+            ]
+
+            if self.ephemeral_storage == []:
+                ebs_volumes.append({
+                    'user': 'root',
+                    'group': 'root',
+                    'size': 8,
+                    'iops': 24,
+                    'device': '/dev/xvdc',
+                    'mount': '/media/ephemeral0'
+                })
+
+                self.log.debug('No instance storage; including swap device')
+
+            self.chef_node.attributes.set_dotted('hudl_ebs.volumes',
+                                                 ebs_volumes)
 
             self.log.info('Configured the hudl_ebs.volumes attribute')
 

--- a/tyr/servers/mongo/config.py
+++ b/tyr/servers/mongo/config.py
@@ -29,8 +29,7 @@ class MongoConfigNode(MongoNode):
         super(MongoConfigNode, self).bake()
 
         with self.chef_api:
-
-            self.chef_node.attributes.set_dotted('hudl_ebs.volumes', [
+            ebs_volumes = [
                 {
                     'user': 'mongod',
                     'group': 'mongod',
@@ -55,7 +54,22 @@ class MongoConfigNode(MongoNode):
                     'device': '/dev/xvdh',
                     'mount': '/mongologs',
                 }
-            ])
+            ]
+
+            self.chef_node.attributes.set_dotted('hudl_ebs.volumes',
+                                                 ebs_volumes)
+
+            if self.ephemeral_storage == []:
+                ebs_volumes.append({
+                    'user': 'root',
+                    'group': 'root',
+                    'size': 8,
+                    'iops': 24,
+                    'device': '/dev/xvdc',
+                    'mount': '/media/ephemeral0'
+                })
+
+                self.log.debug('No instance storage; including swap device')
 
             self.log.info('Configured the hudl_ebs.volumes attribute')
 

--- a/tyr/servers/mongo/data.py
+++ b/tyr/servers/mongo/data.py
@@ -142,7 +142,7 @@ class MongoDataNode(MongoReplicaSetMember):
 
         with self.chef_api:
 
-            self.chef_node.attributes.set_dotted('hudl_ebs.volumes', [
+            ebs_volumes = [
                 {
                     'user': 'mongod',
                     'group': 'mongod',
@@ -167,7 +167,22 @@ class MongoDataNode(MongoReplicaSetMember):
                     'device': '/dev/xvdh',
                     'mount': '/mongologs',
                 }
-            ])
+            ]
+
+            if self.ephemeral_storage == []:
+                ebs_volumes.append({
+                    'user': 'root',
+                    'group': 'root',
+                    'size': 8,
+                    'iops': 24,
+                    'device': '/dev/xvdc',
+                    'mount': '/media/ephemeral0'
+                })
+
+                self.log.debug('No instance storage; including swap device')
+
+            self.chef_node.attributes.set_dotted('hudl_ebs.volumes',
+                                                 ebs_volumes)
 
             self.log.info('Configured the hudl_ebs.volumes attribute')
 

--- a/tyr/servers/server.py
+++ b/tyr/servers/server.py
@@ -17,7 +17,7 @@ from boto.vpc import VPCConnection
 from paramiko.client import AutoAddPolicy, SSHClient
 from tyr.policies import policies
 from tyr.utilities.stackdriver import set_maintenance_mode
-
+import cloudspecs.aws.ec2
 
 class Server(object):
 
@@ -788,6 +788,10 @@ named {name}""".format(path=d['path'], name=d['name']))
     def tag(self):
         self.ec2.create_tags([self.instance.id], self.tags)
         self.log.info('Tagged instance with {tags}'.format(tags=self.tags))
+
+    @property
+    def ephemeral_storage(self):
+        return cloudspecs.aws.ec2.instances[self.instance_type]['instance_storage']
 
     def route(self, wait=False):
 

--- a/tyr/servers/server.py
+++ b/tyr/servers/server.py
@@ -219,13 +219,15 @@ class Server(object):
         if self.block_devices is None:
             self.log.warn('No block devices provided')
 
-            self.block_devices = [
-                {
-                    'type': 'ephemeral',
-                    'name': 'ephemeral0',
-                    'path': 'xvdc'
-                }
-            ]
+            if self.ephemeral_storage != []:
+                self.log.info('Defining ephemeral storage devices')
+                self.block_devices = [
+                    {
+                        'type': 'ephemeral',
+                        'name': 'ephemeral0',
+                        'path': 'xvdc'
+                    }
+                ]
 
         self.log.info('Using EC2 block devices {devices}'.format(
                       devices=self.block_devices))
@@ -467,6 +469,9 @@ chef-client -S 'http://chef.app.hudl.com/' -N {name} -L {logfile}
         bdm = boto.ec2.blockdevicemapping.BlockDeviceMapping()
 
         self.log.info('Created new Block Device Mapping')
+
+        if self.block_devices is None:
+            return bdm
 
         for d in self.block_devices:
 


### PR DESCRIPTION
To quote myself from [`role_mongo` pull request 57][0]:

> EC2 provides many different types of instances, some which support instance storage (ephemeral storage), and some which don't.

> On instances that support instance storage, the device (`/dev/xvdc`) is formatted as `ext3` and mounted at `/media/ephemeral0`. The swap file, created by `role_mongo`, is then placed there. On instances that don't support instance storage, the swap file is still placed there, but it's now on the root device. This can cause problems when the root device is ~8 GB and holds the operating system as well as a swap file that's nearly 50% of it's size.

> A separate pull request to Tyr fixes that - MongoDB instances that don't support instance storage will automatically be launched with an additional 8 GB EBS volume located at `/dev/xvdc` and mounted to `/media/ephemeral0`.

This is that pull request.

[0]: https://github.com/hudl/role_mongo/pull/57