### PR TITLE
Amazon Linux 2016.03 Support

### DIFF
--- a/tyr/servers/server.py
+++ b/tyr/servers/server.py
@@ -165,7 +165,7 @@ class Server(object):
         if self.ami is None:
             if self.use_latest_ami is False:
                 self.log.warn('No AMI provided')
-                self.ami = 'ami-8fcee4e5'
+                self.ami = 'ami-6869aa05'
             else:
                 self.log.warn('No AMI provided, searching for latest one...')
                 self.ami = self.get_latest_ami(self.ami)
@@ -448,7 +448,7 @@ Content-Disposition: attachment; filename="cloud-config.txt"
 
 #cloud-config
 repo_upgrade: none
-repo_releasever: 2015.03
+repo_releasever: 2016.03
 
 --===============0035287898381899620==
 Content-Type: text/x-shellscript; charset="us-ascii"


### PR DESCRIPTION
This updates the default AMI to `Amazon Linux 2016.03` (previously `Amazon Linux 2015.09`) and updates the default Linux cloud config user data to use the correct repository version (previously `2015.03`).

<img src="https://media.giphy.com/media/Cqe23cU00bpAY/giphy.gif" width="100%"/>