### PR TITLE
Attached the allow-mongo-backup-restore Managed IAM Policy to Stage MongoDB Nodes

### DIFF
--- a/tyr/servers/mongo/node.py
+++ b/tyr/servers/mongo/node.py
@@ -46,7 +46,7 @@ class MongoNode(Server):
             self.IAM_ROLE_POLICIES.append('allow-mongo-backup-snapshot')
         elif self.environment == "stage":
             self.IAM_ROLE_POLICIES.append('allow-mongo-snapshot-cleanup')
-
+            self.IAM_MANAGED_POLICIES.append('allow-mongo-backup-restore')
         self.resolve_iam_role()
 
         if self.mongodb_version is None:


### PR DESCRIPTION
This attaches the `allow-mongo-backup-restore` IAM policy to MongoDB nodes in the stage environment to allow them to run the Multiverse Stage Updater.