### PR TITLE
Gamma-230: added appNames to user data

### DIFF
--- a/data/user_data_base.ps2
+++ b/data/user_data_base.ps2
@@ -199,10 +199,10 @@ function Get-MyName {
     return $nameTag.Value
 }
 
-function Get-AppNames {
+function Get-Apps {
     $instanceId = (New-Object System.Net.WebClient).DownloadString("http://169.254.169.254/latest/meta-data/instance-id")
-    $appNameTag =  Get-EC2Tag | ` Where-Object {$_.ResourceId -eq $instanceId -and $_.Key -eq 'AppNames'}
-    return $appNameTag.Value
+    $appsTag =  Get-EC2Tag | Where-Object {$_.ResourceId -eq $instanceId -and $_.Key -eq 'Apps'}
+    return $apps.Value
 }
 
 $TextInfo = (Get-Culture).TextInfo
@@ -228,7 +228,7 @@ $File = Get-Content "c:\hudl\config\servername.txt"
 New-EC2Tag -Region $region -ResourceId $instanceId -Tag @{key="Name"; value="$servername"}
 
 $roleAttributes = Get-HudlRoleAttributes
-$appNames = Get-AppNames
+$apps = Get-Apps
 
 # Set role tag if not set.
 $chef_tag_role = Get-EC2Tag -Filters @( @{Name="key"; values="Role"}, @{Name="resource-id"; Values=$instanceId})
@@ -376,7 +376,7 @@ try {
         "service": "$($roleAttributes.Group)",
         "eureka_set": "$($eurekaSet)",
         "treat_monolith_as_multiverse": $($roleAttributes.TreatMonolithAsMultiverse | ConvertTo-Json),
-        "appNames": "$($appNames)" 
+        "apps": "$($apps)" 
 "@
 
 $dynamicAttributes | % getEnumerator | % {

--- a/data/user_data_base.ps2
+++ b/data/user_data_base.ps2
@@ -106,10 +106,16 @@ function Get-HudlRoleAttributes {
         $environmentPrefix = $roleSplit[0]
         $group = $roleSplit[1]
         $serverRole = $roleSplit[2]
-        # special case for monolith here
+
+        # this block is needed until the old monolith is phased out completely,
+        # to make this compatible with old monolith ASG, add TreatAsNonMultiverseMonolith tag
+        # to the ASG and set the value to yes
         if ($group -eq "monolith"){
-            $serverRole = "Web"
-            $treatMonolithAsMultiverse = $true
+            # check the TreatAsNonMultiverseMonolith tag
+            $isNonMultiverseMonolith = Get-TreatAsNonMultiverseMonolith
+            if (-not $isNonMultiverseMonolith) {
+                $treatMonolithAsMultiverse = $true
+            }
         }
     } 
     # Thors should be treated as multiverse servers now
@@ -213,6 +219,15 @@ function Get-Apps {
     $instanceId = (New-Object System.Net.WebClient).DownloadString("http://169.254.169.254/latest/meta-data/instance-id")
     $appsTag =  Get-EC2Tag | Where-Object {$_.ResourceId -eq $instanceId -and $_.Key -eq 'Apps'}
     return $appsTag.Value
+}
+
+function Get-TreatAsNonMultiverseMonolith {
+    $instanceId = (New-Object System.Net.WebClient).DownloadString("http://169.254.169.254/latest/meta-data/instance-id")
+    $tag =  Get-EC2Tag | Where-Object {$_.ResourceId -eq $instanceId -and $_.Key -eq 'TreatAsNonMultiverseMonolith'}
+    if ($tag -and $tag.Value.ToLower() -eq "yes"){
+        return $true
+    }
+    return $false
 }
 
 $TextInfo = (Get-Culture).TextInfo

--- a/data/user_data_base.ps2
+++ b/data/user_data_base.ps2
@@ -106,6 +106,11 @@ function Get-HudlRoleAttributes {
         $environmentPrefix = $roleSplit[0]
         $group = $roleSplit[1]
         $serverRole = $roleSplit[2]
+        # special case for monolith here
+        if ($group -eq "monolith"){
+            $serverRole = "Web"
+            $treatMonolithAsMultiverse = $true
+        }
     } 
     # Thors should be treated as multiverse servers now
     elseif ($role -eq "thor") {

--- a/data/user_data_base.ps2
+++ b/data/user_data_base.ps2
@@ -96,7 +96,7 @@ function Get-HudlRoleAttributes {
         $serverRole = $roleSplit[1]
         $group = "monolith"
         # special case for queuedservices here
-        if ($serverRole.downcase -eq "queues") {
+        if ($serverRole -eq "queues") {
             $serverRole = "Web"
         }
         

--- a/data/user_data_base.ps2
+++ b/data/user_data_base.ps2
@@ -95,9 +95,10 @@ function Get-HudlRoleAttributes {
         $environmentPrefix = $roleSplit[0]
         $serverRole = $roleSplit[1]
         $group = "monolith"
-        # special case for queuedservices here
-        if ($serverRole -eq "queues") {
+        # special case for queuedservices and admin here
+        if ($serverRole -eq "queues" -or $serverRole -eq "admin") {
             $serverRole = "Web"
+            $treatMonolithAsMultiverse = $true
         }
         
     } elseif ($roleSplit.Length -eq 3) {
@@ -206,7 +207,7 @@ function Get-MyName {
 function Get-Apps {
     $instanceId = (New-Object System.Net.WebClient).DownloadString("http://169.254.169.254/latest/meta-data/instance-id")
     $appsTag =  Get-EC2Tag | Where-Object {$_.ResourceId -eq $instanceId -and $_.Key -eq 'Apps'}
-    return $apps.Value
+    return $appsTag.Value
 }
 
 $TextInfo = (Get-Culture).TextInfo

--- a/data/user_data_base.ps2
+++ b/data/user_data_base.ps2
@@ -95,6 +95,10 @@ function Get-HudlRoleAttributes {
         $environmentPrefix = $roleSplit[0]
         $serverRole = $roleSplit[1]
         $group = "monolith"
+        # special case for queuedservices here
+        if ($serverRole.downcase == "queues") {
+            $serverRole = "Web"
+        }
         
     } elseif ($roleSplit.Length -eq 3) {
         # [0] - Environment Letter, [1] - mvgroupmvgroup, [2] - server role

--- a/data/user_data_base.ps2
+++ b/data/user_data_base.ps2
@@ -199,6 +199,12 @@ function Get-MyName {
     return $nameTag.Value
 }
 
+function Get-AppNames {
+    $instanceId = (New-Object System.Net.WebClient).DownloadString("http://169.254.169.254/latest/meta-data/instance-id")
+    $appNameTag =  Get-EC2Tag | ` Where-Object {$_.ResourceId -eq $instanceId -and $_.Key -eq 'AppNames'}
+    return $appNameTag.Value
+}
+
 $TextInfo = (Get-Culture).TextInfo
 
 ### Determine server name and set it
@@ -222,6 +228,7 @@ $File = Get-Content "c:\hudl\config\servername.txt"
 New-EC2Tag -Region $region -ResourceId $instanceId -Tag @{key="Name"; value="$servername"}
 
 $roleAttributes = Get-HudlRoleAttributes
+$appNames = Get-AppNames
 
 # Set role tag if not set.
 $chef_tag_role = Get-EC2Tag -Filters @( @{Name="key"; values="Role"}, @{Name="resource-id"; Values=$instanceId})
@@ -368,7 +375,8 @@ try {
         "group": "$($roleAttributes.Group)",
         "service": "$($roleAttributes.Group)",
         "eureka_set": "$($eurekaSet)",
-        "treat_monolith_as_multiverse": $($roleAttributes.TreatMonolithAsMultiverse | ConvertTo-Json) 
+        "treat_monolith_as_multiverse": $($roleAttributes.TreatMonolithAsMultiverse | ConvertTo-Json),
+        "appNames": "$($appNames)" 
 "@
 
 $dynamicAttributes | % getEnumerator | % {

--- a/data/user_data_base.ps2
+++ b/data/user_data_base.ps2
@@ -96,7 +96,7 @@ function Get-HudlRoleAttributes {
         $serverRole = $roleSplit[1]
         $group = "monolith"
         # special case for queuedservices here
-        if ($serverRole.downcase == "queues") {
+        if ($serverRole.downcase -eq "queues") {
             $serverRole = "Web"
         }
         


### PR DESCRIPTION
Gamma is going to create different ASG for hudl, admin and queuedservices, when these server spins up it should install only the respective app to those servers, so a QS shouldn't be installing admin, and admin shouldn't be installing hudl, etc. The AppNames will dictate what apps can be installed on the server.

**Rollout**
Add `TreatAsNonMultiverseMonolith` tag to existing monolith ASG with value `yes` iif launch configuration for the ASG is changed.