### PR TITLE
Fetch Windows User Data From GitHub

### DIFF
--- a/data/user_data_fetch_github.ps2
+++ b/data/user_data_fetch_github.ps2
@@ -1,0 +1,12 @@
+<powershell>
+# Fetch Windows User Data from GitHub
+
+$USER_DATA_URI = "https://github.com/hudl/Tyr/raw/master/data/user_data_base.ps2"
+$USER_DATA_FILE_PATH = "c:\\hudl\\user_data_base.ps1"
+
+Write-Output "Fetching user data from GitHub"
+Invoke-WebRequest $USER_DATA_URI -OutFile $USER_DATA_FILE_PATH
+
+Write-Output "Executing user data"
+Invoke-Expression $USER_DATA_FILE_PATH
+</powershell>

--- a/data/user_data_fetch_github.ps2
+++ b/data/user_data_fetch_github.ps2
@@ -1,8 +1,13 @@
 <powershell>
 # Fetch Windows User Data from GitHub
 
+$HUDL_DIRECTORY = "c:\\hudl"
 $USER_DATA_URI = "https://s3.amazonaws.com/hudl-chef-artifacts/windows/user_data_base.ps2"
 $USER_DATA_FILE_PATH = "c:\\hudl\\user_data_base.ps1"
+
+if(!(Test-Path -Path $HUDL_DIRECTORY )){
+    New-Item -ItemType directory -Path $HUDL_DIRECTORY
+}
 
 Write-Output "Fetching user data from GitHub"
 Invoke-WebRequest $USER_DATA_URI -OutFile $USER_DATA_FILE_PATH

--- a/data/user_data_fetch_github.ps2
+++ b/data/user_data_fetch_github.ps2
@@ -1,7 +1,7 @@
 <powershell>
 # Fetch Windows User Data from GitHub
 
-$USER_DATA_URI = "https://github.com/hudl/Tyr/raw/master/data/user_data_base.ps2"
+$USER_DATA_URI = "https://s3.amazonaws.com/hudl-chef-artifacts/windows/user_data_base.ps2"
 $USER_DATA_FILE_PATH = "c:\\hudl\\user_data_base.ps1"
 
 Write-Output "Fetching user data from GitHub"

--- a/tyr/servers/iis/node.py
+++ b/tyr/servers/iis/node.py
@@ -86,7 +86,7 @@ class IISNode(Server):
         # read in userdata file
         user_data = None
         try:
-            f = data_file('user_data_base.ps2')
+            f = data_file('user_data_base_fetch_github.ps2')
             user_data = f.read()
         except IOError:
             self.log.critical('No user info found, exiting!')


### PR DESCRIPTION
There's a limit of 16 KB for user data in EC2, a limit which we are now hitting with the `user_data_base.ps2` script for Windows instances.

I've added a small "helper" user data script which just fetches the full script from GitHub and executes it. I've also updated the IIS node class to use this new script, so any new Auto-Scaling Groups will automatically use this script. 