### PR TITLE
Fix dir creation to continue if they already exist

### DIFF
--- a/data/user_data_base.ps2
+++ b/data/user_data_base.ps2
@@ -31,7 +31,7 @@ $REGIONS = @{'ap-northeast-1' = 'apne1';
 
 Set-DefaultAWSRegion -Region $region
 
-function Create-DirIfNotPresent {
+function New-DirIfNotPresent {
 Param (
     [Parameter(Mandatory=$True )] [string]$DirPath
 )
@@ -40,9 +40,9 @@ Param (
     }
 }
 
-Create-DirIfNotPresent $BASE_DIR
-Create-DirIfNotPresent $CONFIG
-Create-DirIfNotPresent $LOG_DIR
+New-DirIfNotPresent $BASE_DIR
+New-DirIfNotPresent $CONFIG
+New-DirIfNotPresent $LOG_DIR
 
 # ----------------------------------------------------------------------------------------------
 # download a file

--- a/data/user_data_base.ps2
+++ b/data/user_data_base.ps2
@@ -30,11 +30,19 @@ $REGIONS = @{'ap-northeast-1' = 'apne1';
              'us-west-2'= 'usw2'}
 
 Set-DefaultAWSRegion -Region $region
-try {
-  New-Item $BASE_DIR -type directory
-  New-Item $CONFIG -type directory
-  New-Item $LOG_DIR -type directory
-} catch {}
+
+function Create-DirIfNotPresent {
+Param (
+    [Parameter(Mandatory=$True )] [string]$DirPath
+)
+    if(!(Test-Path -Path $DirPath )){
+        New-Item -ItemType directory -Path $DirPath
+    }
+}
+
+Create-DirIfNotPresent $BASE_DIR
+Create-DirIfNotPresent $CONFIG
+Create-DirIfNotPresent $LOG_DIR
 
 # ----------------------------------------------------------------------------------------------
 # download a file


### PR DESCRIPTION
Since switching to this file being downloaded via S3, one of the directories already exists.  This causes an error to be thrown on creation which was silently caught, stopping the other dir creations from taking place.