### PR TITLE
use chef-client 12.13.47

### DIFF
--- a/data/user_data_chef_provision
+++ b/data/user_data_chef_provision
@@ -106,7 +106,7 @@ echo $SERVERNAMELINE >> /etc/chef/client.rb
 echo 'validation_client_name "chef-validator"' >> /etc/chef/client.rb
 
 /usr/bin/aws s3 cp s3://hudl-chef-artifacts/chef-client/encrypted_data_bag_secret /etc/chef/encrypted_data_bag_secret
-curl -L https://www.opscode.com/chef/install.sh | bash;
+curl -L https://omnitruck.chef.io/install.sh | sudo bash -s -- -v 12.13.37
 yum install -y gcc
 chef-client -S 'http://chef.app.hudl.com/' -N $SERVER_NAME -E $ENVIRONMENT -L /var/log/chef-client.log -j /etc/chef/firstrun.json
 --===============0035287898381899620==--

--- a/tyr/servers/server.py
+++ b/tyr/servers/server.py
@@ -502,7 +502,7 @@ environment "{chef_env}"
 validation_client_name "{validation_client_name}"
 ssl_verify_mode :verify_none' > /etc/chef/client.rb
 /usr/bin/aws s3 cp s3://hudl-chef-artifacts/chef-client/encrypted_data_bag_secret /etc/chef/encrypted_data_bag_secret
-curl -L https://www.opscode.com/chef/install.sh | bash;
+curl -L https://omnitruck.chef.io/install.sh | sudo bash -s -- -v 12.13.37
 yum install -y gcc
 printf "%s" "{attributes}" > /etc/chef/attributes.json
 cp /var/tmp/attributes.json /etc/chef/attributes.json


### PR DESCRIPTION
Chef-client 12.14.60 breaks some places we're using yum.  This is a temporary change to using the older version of chef-client which works until we can get our cookbooks updated.