### PR TITLE
switch linux userdata to chef12

### DIFF
--- a/data/user_data_chef_provision
+++ b/data/user_data_chef_provision
@@ -15,6 +15,8 @@ Content-Transfer-Encoding: 7bit
 Content-Disposition: attachment; filename="user-script.txt"
 #!/bin/bash
 
+CHEF_SERVER="https://chef12-ec2.app.hudl.com/organizations/hudl"
+
 # Get the instance Id from the instance metadata service
 INSTANCE_ID=`wget -qO- http://instance-data/latest/meta-data/instance-id`
 
@@ -27,8 +29,7 @@ REGION="`echo \"$AVAILABILITY_ZONE\" | sed -e 's:\([0-9][0-9]*\)[a-z]*\$:\\1:'`"
 
 AVAILABILITY_ZONE_LETTER="`echo $AVAILABILITY_ZONE | sed 's/.*\(.\)/\1/'`"
 
-# Sleep a bit wait for tags to get set.
-# Get the environment from the tag
+# Get the environment from the tag, waiting until it exists.
 ENVIRONMENT=''
 while [ "$ENVIRONMENT" == '' ]
 do
@@ -38,12 +39,16 @@ done
 
 # Get the role from the tag
 ROLE=`aws ec2 describe-tags --region $REGION --filter "Name=resource-id,Values=$INSTANCE_ID" "Name=key,Values=Role" --output=text | sed -r 's/TAGS\t(.*)\t.*\t.*\t(.*)/\2/'`
+
+# lowercase the role
+ROLE="${ROLE,,}"
+
 # Get the group from the tag
 GROUP=`aws ec2 describe-tags --region $REGION --filter "Name=resource-id,Values=$INSTANCE_ID" "Name=key,Values=Group" --output=text | sed -r 's/TAGS\t(.*)\t.*\t.*\t(.*)/\2/'`
 # Pull that stupid role prefix out of the role.
-ROLE_MINUS_ROLE="$(echo $ROLE | sed -r 's/[Role]+//g')"
+ROLE_MINUS_ROLE="$(echo $ROLE | sed -r 's/role//')"
 # Get the uniqueness from the instance id
-UNIQUENESS="$(echo $INSTANCE_ID | sed -r 's/[i-]+//g')"
+UNIQUENESS="$(echo $INSTANCE_ID | sed -r 's/i-//')"
 # pull the first letter out of the environment
 ENVIRONMENT_PREFIX="$(echo $ENVIRONMENT | head -c 1)"
 # join them all together into a server name
@@ -62,10 +67,12 @@ case $ENVIRONMENT in
 "prod")
   SUBDOMAIN=".app.hudl.com"
   HOSTED_ZONE="Z1LKTAOOYM3H8T"
+  CHEF_SERVER="https://chef12-vpc.app.hudl.com/organizations/hudl"
   ;;
 "stage")
   SUBDOMAIN=".app.staghudl.com"
   HOSTED_ZONE="Z3ETV7KVCRERYL"
+  CHEF_SERVER="https://chef12-ec2.app.hudl.com/organizations/hudl"
   ;;
 *)
   SUBDOMAIN=".thorhudl.com"
@@ -98,15 +105,18 @@ touch /etc/chef/ohai/hints/ec2.json
 echo "{{\"run_list\": [\"role[$ROLE]\"]}}" > /etc/chef/firstrun.json
 
 # Write Validation key to server
-echo '{validation_key}' > /etc/chef/validation.pem
 
-echo 'chef_server_url "http://chef.app.hudl.com/"' > /etc/chef/client.rb
+/usr/bin/aws s3 cp s3://hudl-chef-artifacts/chef-client/validation.pem /etc/chef/validation.pem
+
+CHEFSERVERLINE="chef_server_url \"$CHEF_SERVER\""
+echo $CHEFSERVERLINE > /etc/chef/client.rb
 SERVERNAMELINE="node_name \"$SERVER_NAME\""
 echo $SERVERNAMELINE >> /etc/chef/client.rb
-echo 'validation_client_name "chef-validator"' >> /etc/chef/client.rb
+echo 'validation_client_name "hudl-validator"' >> /etc/chef/client.rb
+echo 'ssl_verify_mode    :verify_none' >> /etc/chef/client.rb
 
 /usr/bin/aws s3 cp s3://hudl-chef-artifacts/chef-client/encrypted_data_bag_secret /etc/chef/encrypted_data_bag_secret
-curl -L https://omnitruck.chef.io/install.sh | sudo bash -s -- -v 12.13.37
+curl -L https://omnitruck.chef.io/install.sh | sudo bash -s -- -v 12.19.36
 yum install -y gcc
-chef-client -S 'http://chef.app.hudl.com/' -N $SERVER_NAME -E $ENVIRONMENT -L /var/log/chef-client.log -j /etc/chef/firstrun.json
+chef-client -S $CHEF_SERVER -N $SERVER_NAME -E $ENVIRONMENT -L /var/log/chef-client.log -j /etc/chef/firstrun.json
 --===============0035287898381899620==--

--- a/data/user_data_chef_provision
+++ b/data/user_data_chef_provision
@@ -154,7 +154,7 @@ echo 'validation_client_name "hudl-validator"' >> /etc/chef/client.rb
 echo 'ssl_verify_mode    :verify_none' >> /etc/chef/client.rb
 
 /usr/bin/aws s3 cp s3://hudl-chef-artifacts/chef-client/encrypted_data_bag_secret /etc/chef/encrypted_data_bag_secret
-curl -L https://omnitruck.chef.io/install.sh | sudo bash -s -- -v 12.13.37
+curl -L https://omnitruck.chef.io/install.sh | sudo bash -s -- -v 12.19.36
 yum install -y gcc
 chef-client -S $CHEF_SERVER -N $SERVER_NAME -E $ENVIRONMENT -L /var/log/chef-client.log -j /etc/chef/firstrun.json
 --===============0035287898381899620==--

--- a/data/user_data_chef_provision
+++ b/data/user_data_chef_provision
@@ -116,7 +116,7 @@ echo 'validation_client_name "hudl-validator"' >> /etc/chef/client.rb
 echo 'ssl_verify_mode    :verify_none' >> /etc/chef/client.rb
 
 /usr/bin/aws s3 cp s3://hudl-chef-artifacts/chef-client/encrypted_data_bag_secret /etc/chef/encrypted_data_bag_secret
-curl -L https://omnitruck.chef.io/install.sh | sudo bash -s -- -v 12.19.36
+curl -L https://omnitruck.chef.io/install.sh | sudo bash -s -- -v 12.13.37
 yum install -y gcc
 chef-client -S $CHEF_SERVER -N $SERVER_NAME -E $ENVIRONMENT -L /var/log/chef-client.log -j /etc/chef/firstrun.json
 --===============0035287898381899620==--

--- a/data/user_data_chef_provision
+++ b/data/user_data_chef_provision
@@ -84,7 +84,7 @@ FULL_HOSTNAME="$SERVER_NAME$SUBDOMAIN"
 
 mkdir /etc/chef
 
-CHANGE="{{\"Comment\": \"Add recordset for $SERVER_NAME\", \"Changes\": [ {{ \"Action\": \"UPSERT\", \"ResourceRecordSet\": {{ \"Name\": \"$FULL_HOSTNAME\", \"Type\": \"CNAME\", \"TTL\": 60, \"ResourceRecords\": [ {{ \"Value\": \"$LOCAL_HOSTNAME\" }} ] }} }} ] }}"
+CHANGE="{\"Comment\": \"Add recordset for $SERVER_NAME\", \"Changes\": [ { \"Action\": \"UPSERT\", \"ResourceRecordSet\": { \"Name\": \"$FULL_HOSTNAME\", \"Type\": \"CNAME\", \"TTL\": 60, \"ResourceRecords\": [ { \"Value\": \"$LOCAL_HOSTNAME\" } ] } } ] }"
 echo $CHANGE > /etc/chef/route53change.json
 
 aws route53 change-resource-record-sets --hosted-zone-id $HOSTED_ZONE --change-batch file:///etc/chef/route53change.json
@@ -101,8 +101,46 @@ touch /etc/chef/client.rb
 mkdir -p /etc/chef/ohai/hints
 touch /etc/chef/ohai/hints/ec2.json
 
+# install boto3
+sudo pip install boto3==1.4.4
+
 # Write first boot json
-echo "{{\"run_list\": [\"role[$ROLE]\"]}}" > /etc/chef/firstrun.json
+echo "{\"run_list\": [\"role[$ROLE]\"]}" > /etc/chef/firstrun.json
+
+SCRIPTPATH="/etc/chef/read-tags.py"
+# write python script file to write the tags to the firstrun.json file.
+cat > $SCRIPTPATH <<- EOM
+import json,sys,boto3,requests;
+
+file_path_input = "/etc/chef/firstrun.json"
+file_path_output = file_path_input
+client = boto3.client('ec2', region_name='us-east-1')
+tag_prefix = 'chef:hudl:'
+# Get my instance id
+response = requests.get('http://169.254.169.254/latest/meta-data/instance-id')
+instance_id = response.text
+# Get chef:hudl tags
+tags = client.describe_tags(Filters=[{'Name':'resource-id','Values':[instance_id]}, {'Name': 'key','Values': [tag_prefix + "*"]}])
+tag_dict = tags['Tags']
+# check if we have any chef:hudl tags
+if len(tag_dict) > 0:
+    # Read current first run json.
+    with open(file_path_input, mode='r') as input_file:
+        contents = json.load(input_file)
+        contents['hudl'] = {}
+        # Write new first run json, with data from tags
+        with open(file_path_output, mode='w') as output_file:
+            for tag in tag_dict:
+                key = tag['Key'].replace(tag_prefix,"")
+                value = tag['Value']
+                contents['hudl'][key] = value
+                print "Added config from tag: %s" % key
+            json.dump(contents, output_file)
+else:
+    print "No chef:hudl tags, not modifying %s" % file_path_input
+EOM
+
+python $SCRIPTPATH
 
 # Write Validation key to server
 

--- a/tyr/servers/nginx/server.py
+++ b/tyr/servers/nginx/server.py
@@ -59,12 +59,7 @@ class NginxServer(Server):
             f = data_file('user_data_chef_provision')
             user_data = f.read()
 
-            chef_path = os.path.expanduser(self.chef_path)
-            validation_key_path = os.path.join(chef_path, 'chef-validator.pem')
-            validation_key_file = open(validation_key_path, 'r')
-            validation_key = validation_key_file.read()
-
-            return user_data.format(validation_key=validation_key)
+            return user_data
 
         except IOError:
             self.log.critical('chef-validator key not found!')


### PR DESCRIPTION
This switches the linux userdata (used in Craft and Nginx ASGs) to use chef12 rather than chef11

* Switches the chef server path
* Switches to use uses lowercase roles, our chef12 server is using lowercase role names.
* Updates chef-client from 12.13.37 to 12.19.36 
* Disables ssl_verify_mode, since our chef12 server doesn't have SSL setup.
* switches the validator name from chef-validator to hudl-validator
* switches to pull the chef validator from s3 rather than being read into a template.
* adds support for reading chef attributes from ec2 tags. the tag must start with `chef:hudl` to support changes in https://github.com/hudl/role_nginx/pull/45