### PR TITLE
Support for Provisioning MongoDB Nodes from Snapshots

### DIFF
--- a/tyr/servers/mongo/config.py
+++ b/tyr/servers/mongo/config.py
@@ -17,7 +17,7 @@ class MongoConfigNode(MongoNode):
                  chef_path=None, subnet_id=None, dns_zones=None,
                  ingress_groups_to_add=None, ports_to_authorize=None,
                  classic_link=False, add_route53_dns=True,
-                 chef_server_url=None):
+                 chef_server_url=None, data_volume_snapshot_id=None):
 
         super(MongoConfigNode, self).__init__(group, server_type,
                                               instance_type,
@@ -30,6 +30,9 @@ class MongoConfigNode(MongoNode):
                                               ports_to_authorize, classic_link,
                                               add_route53_dns, chef_server_url)
 
+        self.data_volume_snapshot_id = data_volume_snapshot_id
+                                              
+
     def set_chef_attributes(self):
         super(MongoConfigNode, self).set_chef_attributes()
 
@@ -38,7 +41,8 @@ class MongoConfigNode(MongoNode):
                 'device': {
                     'path': '/dev/xvdf',
                     'size': 5,
-                    'name': 'mongodb-data'
+                    'name': 'mongodb-data',
+                    'snapshot_id': self.data_volume_snapshot_id
                 },
                 'mount': {
                     'path': '/volr',

--- a/tyr/servers/mongo/data.py
+++ b/tyr/servers/mongo/data.py
@@ -18,9 +18,9 @@ class MongoDataNode(MongoReplicaSetMember):
                  ingress_groups_to_add=None, ports_to_authorize=None,
                  classic_link=False, add_route53_dns=True, chef_server_url=None,
                  replica_set=None, mongodb_version=None, data_volume_size=None,
-                 data_volume_iops=None, journal_volume_size=None,
-                 journal_volume_iops=None, log_volume_size=None,
-                 log_volume_iops=None):
+                 data_volume_iops=None, data_volume_snapshot_id=None,
+                 journal_volume_size=None, journal_volume_iops=None,
+                 log_volume_size=None, log_volume_iops=None):
 
         super(MongoDataNode, self).__init__(group, server_type, instance_type,
                                             environment, ami, region, role,
@@ -34,6 +34,7 @@ class MongoDataNode(MongoReplicaSetMember):
 
         self.data_volume_size = data_volume_size
         self.data_volume_iops = data_volume_iops
+        self.data_volume_snapshot_id = data_volume_snapshot_id
         self.journal_volume_size = journal_volume_size
         self.journal_volume_iops = journal_volume_iops
         self.log_volume_size = log_volume_size
@@ -135,7 +136,8 @@ class MongoDataNode(MongoReplicaSetMember):
                     'path': '/dev/xvdf',
                     'size': self.data_volume_size,
                     'iops': self.data_volume_iops,
-                    'name': 'mongodb-data'
+                    'name': 'mongodb-data',
+                    'snapshot_id': self.data_volume_snapshot_id
                 },
                 'mount': {
                     'path': '/volr',


### PR DESCRIPTION
This adds a `data_volume_snapshot_id` argument to `MongoConfigNode` and `MongoDataNode` which supports provisioning MongoDB nodes with data volumes sourced from EBS snapshots.