### PR TITLE
Pass the Chef Path through to ZuunConfig

### DIFF
--- a/tyr/servers/mongo/member.py
+++ b/tyr/servers/mongo/member.py
@@ -52,7 +52,9 @@ class MongoReplicaSetMember(MongoNode):
         ))
         try:
             self.log.warning('Creating ' + 'deployment_{}-{}'.format(self.environment[0], self.group) + " data bag.")
-            ZuunConfig.write_databag(self.environment[0], self.group, replica_set, self.mongodb_version)
+            ZuunConfig.write_databag(self.chef_path, self.environment[0],
+                                     self.group, replica_set,
+                                     self.mongodb_version)
         except Exception as e:
             self.log.error("Failed to create zuun databag config!")
             raise e

--- a/tyr/servers/mongo/zuun.py
+++ b/tyr/servers/mongo/zuun.py
@@ -6,7 +6,7 @@ import base64
 class ZuunConfig():
 
   @staticmethod
-  def write_databag(environment, service, rs, version):
+  def write_databag(chef_path, environment, service, rs, version):
 
       conf_template = """
       net:
@@ -42,7 +42,7 @@ class ZuunConfig():
           }
       }
 
-      api = chef.autoconfigure()
+      api = chef.autoconfigure(chef_path)
       with api:
         bag = chef.DataBag('zuun')
         item_name = 'deployment_{}-{}'.format(environment, service)


### PR DESCRIPTION
The `ZuunConfig` class doesn't inherit from `Server` and therefore doesn't have access to `self.chef_path`. The Chef client was being auto-configured with the default path, ignoring the user's specified `chef_path`. This led to situations where the regular `bake` process for an instance would finish successfully but `ZuunConfig` would error because it was using the incorrect Chef configuration.