### PR TITLE
Expanded Sharded MongoDB Support

### DIFF
--- a/tyr/servers/mongo/__init__.py
+++ b/tyr/servers/mongo/__init__.py
@@ -2,4 +2,3 @@ from data import MongoDataNode
 from router import MongoRouterNode
 from arbiter import MongoArbiterNode
 from config import MongoConfigNode
-from zuun import ZuunConfig

--- a/tyr/servers/mongo/arbiter.py
+++ b/tyr/servers/mongo/arbiter.py
@@ -17,7 +17,7 @@ class MongoArbiterNode(MongoReplicaSetMember):
                  chef_path=None, subnet_id=None,
                  ingress_groups_to_add=None, ports_to_authorize=None,
                  classic_link=False, chef_server_url=None,
-                 replica_set=None):
+                 mongodb_version=None, replica_set=None):
 
         super(MongoArbiterNode, self).__init__(group, server_type,
                                                instance_type,
@@ -27,7 +27,8 @@ class MongoArbiterNode(MongoReplicaSetMember):
                                                chef_path, subnet_id,
                                                ingress_groups_to_add,
                                                ports_to_authorize, classic_link,
-                                               chef_server_url, replica_set)
+                                               chef_server_url, mongodb_version,
+                                               replica_set)
 
     def set_chef_attributes(self):
         super(MongoArbiterNode, self).set_chef_attributes()

--- a/tyr/servers/mongo/config.py
+++ b/tyr/servers/mongo/config.py
@@ -1,7 +1,7 @@
 from member import MongoReplicaSetMember
 
 
-class MongoConfigNode(MongoNode):
+class MongoConfigNode(MongoReplicaSetMember):
 
     NAME_TEMPLATE = '{envcl}-cfg-{location}'
     NAME_SEARCH_PREFIX = '{envcl}-cfg-{location}-'
@@ -16,8 +16,8 @@ class MongoConfigNode(MongoNode):
                  security_groups=None, block_devices=None,
                  chef_path=None, subnet_id=None,
                  ingress_groups_to_add=None, ports_to_authorize=None,
-                 classic_link=False, chef_server_url=None, replica_set=None,
-                 mongodb_version=None, data_volume_snapshot_id=None):
+                 classic_link=False, chef_server_url=None, mongodb_version=None,
+                 replica_set=None, data_volume_snapshot_id=None):
 
         super(MongoConfigNode, self).__init__(group, server_type,
                                               instance_type,
@@ -28,8 +28,8 @@ class MongoConfigNode(MongoNode):
                                               subnet_id,
                                               ingress_groups_to_add,
                                               ports_to_authorize, classic_link,
-                                              chef_server_url, replica_set,
-                                              mongodb_version)
+                                              chef_server_url, mongodb_version,
+                                              replica_set)
 
         self.data_volume_snapshot_id = data_volume_snapshot_id
                                               

--- a/tyr/servers/mongo/config.py
+++ b/tyr/servers/mongo/config.py
@@ -1,11 +1,11 @@
-from node import MongoNode
+from member import MongoReplicaSetMember
 
 
 class MongoConfigNode(MongoNode):
 
     NAME_TEMPLATE = '{envcl}-cfg-{location}'
-    NAME_SEARCH_PREFIX = '{envcl}-cfg-'
-    NAME_AUTO_INDEX = False
+    NAME_SEARCH_PREFIX = '{envcl}-cfg-{location}-'
+    NAME_AUTO_INDEX = True
 
     CHEF_RUNLIST = ['role[RoleMongo]']
     CHEF_MONGODB_TYPE = 'config'
@@ -16,8 +16,8 @@ class MongoConfigNode(MongoNode):
                  security_groups=None, block_devices=None,
                  chef_path=None, subnet_id=None,
                  ingress_groups_to_add=None, ports_to_authorize=None,
-                 classic_link=False, chef_server_url=None,
-                 data_volume_snapshot_id=None):
+                 classic_link=False, chef_server_url=None, replica_set=None,
+                 mongodb_version=None, data_volume_snapshot_id=None):
 
         super(MongoConfigNode, self).__init__(group, server_type,
                                               instance_type,
@@ -28,7 +28,8 @@ class MongoConfigNode(MongoNode):
                                               subnet_id,
                                               ingress_groups_to_add,
                                               ports_to_authorize, classic_link,
-                                              chef_server_url)
+                                              chef_server_url, replica_set,
+                                              mongodb_version)
 
         self.data_volume_snapshot_id = data_volume_snapshot_id
                                               

--- a/tyr/servers/mongo/data.py
+++ b/tyr/servers/mongo/data.py
@@ -3,8 +3,8 @@ import sys
 
 class MongoDataNode(MongoReplicaSetMember):
 
-    NAME_TEMPLATE = '{envcl}-rs{replica_set}-{location}-{index}'
-    NAME_SEARCH_PREFIX = '{envcl}-rs{replica_set}-{location}-'
+    NAME_TEMPLATE = '{envcl}-rs{replica_set_index}-{location}-{index}'
+    NAME_SEARCH_PREFIX = '{envcl}-rs{replica_set_index}-{location}-'
     NAME_AUTO_INDEX = True
 
     CHEF_RUNLIST = ['role[rolemongo]', 'recipe[zuun::configure]']
@@ -21,6 +21,8 @@ class MongoDataNode(MongoReplicaSetMember):
                  data_volume_iops=None, data_volume_snapshot_id=None,
                  journal_volume_size=None, journal_volume_iops=None,
                  log_volume_size=None, log_volume_iops=None):
+
+        self.replica_set = replica_set or '1'        
 
         super(MongoDataNode, self).__init__(group, server_type, instance_type,
                                             environment, ami, region, role,
@@ -39,6 +41,7 @@ class MongoDataNode(MongoReplicaSetMember):
         self.journal_volume_iops = journal_volume_iops
         self.log_volume_size = log_volume_size
         self.log_volume_iops = log_volume_iops
+        self.replica_set_index = int(self.replica_set)
 
 
     def set_chef_attributes(self):

--- a/tyr/servers/mongo/data.py
+++ b/tyr/servers/mongo/data.py
@@ -16,8 +16,8 @@ class MongoDataNode(MongoReplicaSetMember):
                  security_groups=None, block_devices=None,
                  chef_path=None, subnet_id=None,
                  ingress_groups_to_add=None, ports_to_authorize=None,
-                 classic_link=False, chef_server_url=None, replica_set=None,
-                 mongodb_version=None, data_volume_size=None,
+                 classic_link=False, chef_server_url=None, mongodb_version=None,
+                 replica_set=None, data_volume_size=None,
                  data_volume_iops=None, data_volume_snapshot_id=None,
                  journal_volume_size=None, journal_volume_iops=None,
                  log_volume_size=None, log_volume_iops=None):
@@ -29,8 +29,8 @@ class MongoDataNode(MongoReplicaSetMember):
                                             chef_path, subnet_id,
                                             ingress_groups_to_add,
                                             ports_to_authorize, classic_link,
-                                            chef_server_url, replica_set,
-                                            mongodb_version)
+                                            chef_server_url, mongodb_version,
+                                            replica_set)
 
         self.data_volume_size = data_volume_size
         self.data_volume_iops = data_volume_iops

--- a/tyr/servers/mongo/member.py
+++ b/tyr/servers/mongo/member.py
@@ -1,5 +1,4 @@
 from node import MongoNode
-from zuun import ZuunConfig
 from chef.exceptions import ChefServerError
 
 class MongoReplicaSetMember(MongoNode):
@@ -42,14 +41,6 @@ class MongoReplicaSetMember(MongoNode):
             name=replica_set)
         )
 
-        try:
-            self.log.warning('Creating ' + 'deployment_{}-{}'.format(self.environment[0], self.group) + " data bag.")
-            ZuunConfig.write_databag(self.chef_path, self.environment[0],
-                                     self.group, replica_set,
-                                     self.mongodb_version)
-        except Exception as e:
-            self.log.error("Failed to create zuun databag config!")
-            raise e
 
     def configure(self):
         super(MongoReplicaSetMember, self).configure()

--- a/tyr/servers/mongo/member.py
+++ b/tyr/servers/mongo/member.py
@@ -13,7 +13,7 @@ class MongoReplicaSetMember(MongoNode):
                  chef_path=None, subnet_id=None,
                  ingress_groups_to_add=None, ports_to_authorize=None,
                  classic_link=False, chef_server_url=None,
-                 replica_set=None, mongodb_version=None):
+                 mongodb_version=None, replica_set=None):
 
         super(MongoReplicaSetMember, self).__init__(group, server_type,
                                                     instance_type,
@@ -26,13 +26,10 @@ class MongoReplicaSetMember(MongoNode):
                                                     ingress_groups_to_add,
                                                     ports_to_authorize,
                                                     classic_link,
-                                                    chef_server_url)
-        if replica_set is None:
-            replica_set = "1"
-        if mongodb_version is None:
-            mongodb_version="3.2.9"
-        self.replica_set = replica_set
-        self.mongodb_version = mongodb_version
+                                                    chef_server_url,
+                                                    mongodb_version)
+
+        self.replica_set = replica_set or '1'
 
     def set_chef_attributes(self):
         super(MongoReplicaSetMember, self).set_chef_attributes()

--- a/tyr/servers/mongo/member.py
+++ b/tyr/servers/mongo/member.py
@@ -45,10 +45,6 @@ class MongoReplicaSetMember(MongoNode):
             name=replica_set)
         )
 
-        self.CHEF_ATTRIBUTES['zuun']['replica_set'] = replica_set
-        self.log.info('Set the Zuun replica set to "{name}"'.format(
-            name=replica_set
-        ))
         try:
             self.log.warning('Creating ' + 'deployment_{}-{}'.format(self.environment[0], self.group) + " data bag.")
             ZuunConfig.write_databag(self.chef_path, self.environment[0],
@@ -57,7 +53,6 @@ class MongoReplicaSetMember(MongoNode):
         except Exception as e:
             self.log.error("Failed to create zuun databag config!")
             raise e
-
 
     def configure(self):
         super(MongoReplicaSetMember, self).configure()

--- a/tyr/servers/mongo/node.py
+++ b/tyr/servers/mongo/node.py
@@ -20,7 +20,8 @@ class MongoNode(Server):
                  chef_path=None, subnet_id=None,
                  platform=None, use_latest_ami=False,
                  ingress_groups_to_add=None, ports_to_authorize=None,
-                 classic_link=False, chef_server_url=None):
+                 classic_link=False, chef_server_url=None,
+                 mongodb_version=None):
 
         if server_type is None:
             server_type = self.SERVER_TYPE
@@ -33,6 +34,9 @@ class MongoNode(Server):
                                         platform, use_latest_ami,
                                         ingress_groups_to_add, ports_to_authorize,
                                         classic_link, chef_server_url)
+
+        self.mongodb_version = mongodb_version or '3.2.9'
+
 
     def set_chef_attributes(self):
         super(MongoNode, self).set_chef_attributes()

--- a/tyr/servers/mongo/node.py
+++ b/tyr/servers/mongo/node.py
@@ -57,11 +57,23 @@ class MongoNode(Server):
             type_=self.CHEF_MONGODB_TYPE)
         )
 
-        node = zuun.configure_chef_attributes(node)
+        self.CHEF_ATTRIBUTES['zuun'] = {
+            'deployment': self.zuun_deployment,
+            'role': self.CHEF_MONGODB_TYPE,
+
+        }
+
+        try:
+            if self.replica_set:
+                self.CHEF_ATTRIBUTES['zuun']['replica_set'] = self.replica_set
+        except AttributeError:
+            pass
+
 
 
     def configure(self):
         super(MongoNode, self).configure()
+
         self.set_chef_attributes()
 
         if self.environment == 'prod':

--- a/tyr/servers/mongo/node.py
+++ b/tyr/servers/mongo/node.py
@@ -36,6 +36,10 @@ class MongoNode(Server):
                                         classic_link, chef_server_url)
 
         self.mongodb_version = mongodb_version or '3.2.9'
+        self.zuun_deployment = '{env}-{group}'.format(
+            env=self.environment[0],
+            group=self.group
+        )
 
 
     def set_chef_attributes(self):

--- a/tyr/servers/mongo/node.py
+++ b/tyr/servers/mongo/node.py
@@ -1,4 +1,5 @@
 from tyr.servers.server import Server
+import zuun
 import json
 
 
@@ -48,22 +49,7 @@ class MongoNode(Server):
             type_=self.CHEF_MONGODB_TYPE)
         )
 
-        self.CHEF_ATTRIBUTES['zuun'] = {}
-
-        self.CHEF_ATTRIBUTES['zuun']['deployment'] = '{env}-{group}'.format(
-            env=self.environment[0],
-            group=self.group
-        )
-        self.log.info('Set the Zuun deployment to "{env}-{group}"'.format(
-            env=self.environment[0],
-            group=self.group
-        ))
-
-        self.CHEF_ATTRIBUTES['zuun']['role'] = self.CHEF_MONGODB_TYPE
-        self.log.info('Set the Zuun role to "{type_}"'.format(
-            type_=self.CHEF_MONGODB_TYPE)
-        )
-
+        node = zuun.configure_chef_attributes(node)
 
 
     def configure(self):

--- a/tyr/servers/mongo/router.py
+++ b/tyr/servers/mongo/router.py
@@ -17,7 +17,7 @@ class MongoRouterNode(MongoNode):
                  chef_path=None, subnet_id=None,
                  ingress_groups_to_add=None, ports_to_authorize=None,
                  classic_link=False, chef_server_url=None,
-                 mongo_configDB=None):
+                 mongodb_version=None, mongodb_configDB=None):
 
         super(MongoRouterNode, self).__init__(group, server_type,
                                               instance_type,
@@ -28,9 +28,10 @@ class MongoRouterNode(MongoNode):
                                               subnet_id,
                                               ingress_groups_to_add,
                                               ports_to_authorize, classic_link,
-                                              chef_server_url)
+                                              chef_server_url,
+                                              mongodb_version)
 
-        self.mongo_configDB = mongo_configDB
+        self.mongodb_configDB = mongodb_configDB
 
 
 def set_chef_attributes(self):

--- a/tyr/servers/mongo/router.py
+++ b/tyr/servers/mongo/router.py
@@ -16,7 +16,8 @@ class MongoRouterNode(MongoNode):
                  security_groups=None, block_devices=None,
                  chef_path=None, subnet_id=None,
                  ingress_groups_to_add=None, ports_to_authorize=None,
-                 classic_link=False, chef_server_url=None):
+                 classic_link=False, chef_server_url=None,
+                 mongo_configDB=None):
 
         super(MongoRouterNode, self).__init__(group, server_type,
                                               instance_type,
@@ -28,6 +29,9 @@ class MongoRouterNode(MongoNode):
                                               ingress_groups_to_add,
                                               ports_to_authorize, classic_link,
                                               chef_server_url)
+
+        self.mongo_configDB = mongo_configDB
+
 
 def set_chef_attributes(self):
     super(MongoConfigNode, self).set_chef_attributes()

--- a/tyr/servers/mongo/zuun.py
+++ b/tyr/servers/mongo/zuun.py
@@ -3,6 +3,34 @@ import sys
 import chef
 import base64
 
+
+def configure_chef_attributes(node):
+  zuun_deployment = '{env}-{group}'.format(
+    env=node.environment[0],
+    group=node.group
+  )
+
+  node.CHEF_ATTRIBUTES['zuun'] = {}
+
+  node.CHEF_ATTRIBUTES['zuun']['deployment'] = zuun_deployment
+
+  node.log.info('Set the Zuun deployment to {deployment}'.format(
+    deployment=zuun_deployment
+  ))
+
+  node.CHEF_ATTRIBUTES['zuun']['role'] = node.CHEF_MONGODB_TYPE
+  node.log.info('Set the Zuun role to "{type_}"'.format(
+    type_=node.CHEF_MONGODB_TYPE)
+  )
+
+  if node.CHEF_MONGODB_TYPE == 'data':
+    node.CHEF_ATTRIBUTES['zuun']['replica_set'] = node.replica_set
+  elif node.CHEF_MONGODB_TYPE == 'config' and node.replica_set is not None:
+    node.CHEF_ATTRIBUTES['zuun']['replica_set'] = node.replica_set
+
+  return node
+
+
 class ZuunConfig():
 
   @staticmethod

--- a/tyr/servers/mongo/zuun.py
+++ b/tyr/servers/mongo/zuun.py
@@ -97,35 +97,35 @@ def generate_mongo_conf(node):
 
 
 def update_data_bag_item(node):
-  data_bag_item_name = 'deployment_{}'.format(
-    node.CHEF_ATTRIBUTES['zuun']['deployment'])
-  search_key = node.replica_set or node.CHEF_MONGODB_TYPE
-  data_bag_item_node_data = {
-    'version': node.mongodb_version,
-    'conf': base64.b64encode(generate_mongo_conf(node))
-  }
+    data_bag_item_name = 'deployment_{}'.format(
+        node.CHEF_ATTRIBUTES['zuun']['deployment'])
+    search_key = node.replica_set or node.CHEF_MONGODB_TYPE
+    data_bag_item_node_data = {
+        'version': node.mongodb_version,
+        'conf': base64.b64encode(generate_mongo_conf(node))
+    }
 
-  data_bag_item = {'replica-sets': {}}
+    data_bag_item = {'replica-sets': {}}
   
-  with chef.autoconfigure(node.chef_path):
-    data_bag = chef.DataBag('zuun')
+    with chef.autoconfigure(node.chef_path):
+        data_bag = chef.DataBag('zuun')
   
-    if data_bag_item_name in data_bag.keys():
-      node.log.info('Data bag item {} already exists; updating (but not overwriting) if required'.format(data_bag_item_name))
-      data_bag_item = chef.DataBagItem(data_bag, data_bag_item_name)
+        if data_bag_item_name in data_bag.keys():
+            node.log.info('Data bag item {} already exists; updating (but not overwriting) if required'.format(data_bag_item_name))
+            data_bag_item = chef.DataBagItem(data_bag, data_bag_item_name)
 
-      source = data_bag_item['replica-sets'] if node.replica_set else data_bag_item
+            source = data_bag_item['replica-sets'] if node.replica_set else data_bag_item
 
-      if search_key not in source:
-        source[key] = data_bag_item_node_data
-        data_bag_item.save()
-    else:
-      node.log.info('Data bag item {} does not exist; creating'.format(data_bag_item_name))
+            if search_key not in source:
+                source[key] = data_bag_item_node_data
+                data_bag_item.save()
+        else:
+            node.log.info('Data bag item {} does not exist; creating'.format(data_bag_item_name))
 
-      source = data_bag_item['replica-sets'] if node.replica_set else data_bag_item      
-      source[search_key] = data_bag_item_node_data
+            source = data_bag_item['replica-sets'] if node.replica_set else data_bag_item      
+            source[search_key] = data_bag_item_node_data
 
-      chef.DataBagItem.create('zuun', data_bag_item_name, **data_bag_item)
+            chef.DataBagItem.create('zuun', data_bag_item_name, **data_bag_item)
 
 
     

--- a/tyr/servers/mongo/zuun.py
+++ b/tyr/servers/mongo/zuun.py
@@ -4,33 +4,6 @@ import chef
 import base64
 
 
-def configure_chef_attributes(node):
-  zuun_deployment = '{env}-{group}'.format(
-    env=node.environment[0],
-    group=node.group
-  )
-
-  node.CHEF_ATTRIBUTES['zuun'] = {}
-
-  node.CHEF_ATTRIBUTES['zuun']['deployment'] = zuun_deployment
-
-  node.log.info('Set the Zuun deployment to {deployment}'.format(
-    deployment=zuun_deployment
-  ))
-
-  node.CHEF_ATTRIBUTES['zuun']['role'] = node.CHEF_MONGODB_TYPE
-  node.log.info('Set the Zuun role to "{type_}"'.format(
-    type_=node.CHEF_MONGODB_TYPE)
-  )
-
-  if node.CHEF_MONGODB_TYPE == 'data':
-    node.CHEF_ATTRIBUTES['zuun']['replica_set'] = node.replica_set
-  elif node.CHEF_MONGODB_TYPE == 'config' and node.replica_set is not None:
-    node.CHEF_ATTRIBUTES['zuun']['replica_set'] = node.replica_set
-
-  return node
-
-
 class ZuunConfig():
 
   @staticmethod


### PR DESCRIPTION
- Moves the `mongodb_version` param to `MongoNode`, adding support for it to all MongoDB nodes
- Enables instance name indexing for MongoDB Config nodes
- Adds a `mongodb_configDB` param to `MongoRouterNode` which allows the user to set the MongoDB config server locations for new deployments
- Adds a  `replica_set` param to `MongoConfigNode` which allows a MongoDB config node to be configured as a replica set member
- Adds support for adding MongoDB config and router node configurations in Zuun Chef data bag items
- Avoids overwriting existing configurations in the Zuun data bag
- Adds `recoverShardingState: false` to the MongoDB conf of all new MongoDB config node deployments that are not in `prod`
- Supports the proper tagging of replica sets with irregular names (e.g. `RS1` or `configHighlights`)