### PR TITLE
Consider Subnet Configuration When Associating Public IPs with VPC Instances

### DIFF
--- a/tyr/servers/server.py
+++ b/tyr/servers/server.py
@@ -815,10 +815,14 @@ named {name}""".format(path=d['path'], name=d['name']))
                 'security_group_ids': self.security_group_ids,
             })
         else:
+            subnet = VPCConnection().get_all_subnets(
+                filters={'subnet_id': self.subnet_id}
+            )[0]
+
             interface = NetworkInterfaceSpecification(
                 subnet_id=self.subnet_id,
                 groups=self.security_group_ids,
-                associate_public_ip_address=True)
+                associate_public_ip_address=subnet.mapPublicIpOnLaunch)
             interfaces = NetworkInterfaceCollection(
                 interface)
             parameters.update({

--- a/tyr/servers/server.py
+++ b/tyr/servers/server.py
@@ -819,10 +819,13 @@ named {name}""".format(path=d['path'], name=d['name']))
                 filters={'subnet_id': self.subnet_id}
             )[0]
 
+            mapPublicIpOnLaunch = {'false': False,
+                                   'true': True}[subnet.mapPublicIpOnLaunch]
+
             interface = NetworkInterfaceSpecification(
                 subnet_id=self.subnet_id,
                 groups=self.security_group_ids,
-                associate_public_ip_address=subnet.mapPublicIpOnLaunch)
+                associate_public_ip_address=mapPublicIpOnLaunch)
             interfaces = NetworkInterfaceCollection(
                 interface)
             parameters.update({


### PR DESCRIPTION
If a `subnet_id` is specified, it checks whether the subnet is configured to auto-assign a public IP or not. If not, it won't associate a public IP with the instance on launch.

Fixes #149.