### PR TITLE
Retrieve AWS account ID via STS get_caller_identity

### DIFF
--- a/tyr/servers/server.py
+++ b/tyr/servers/server.py
@@ -653,10 +653,10 @@ named {name}""".format(path=d['path'], name=d['name']))
         if (len(self.IAM_MANAGED_POLICIES) > 0):
             self.log.info("Adding managed policies [" + str(self.IAM_MANAGED_POLICIES).format(environment=self.environment) + "] to role [" + self.role + "]")
 
+            account_id = boto3.client('sts').get_caller_identity()['Account']
+
             for m_policy in self.IAM_MANAGED_POLICIES:
                 m_policy_id = m_policy.format(environment=self.environment)
-                arn = self.iam.get_user().user.arn
-                account_id = arn[arn.find('::')+2:arn.rfind(':')]
                 m_policy_arn = self.iam.get_policy("arn:aws:iam::{account_id}:policy/{policy}".format(account_id=account_id, policy=m_policy_id))
                 self.iam.attach_role_policy("arn:aws:iam::{account_id}:policy/{policy}".format(account_id=account_id, policy=m_policy_id), self.role)
 


### PR DESCRIPTION
Running Tyr on an EC2 instance where Tyr receives its AWS credentials via IAM Role causes the error

```
Traceback (most recent call last):
  File "/virtualenvs/hostedtyr/local/lib/python2.7/site-packages/gunicorn/workers/async.py", line 56, in handle
    self.handle_request(listener_name, req, client, addr)
  File "/virtualenvs/hostedtyr/local/lib/python2.7/site-packages/gunicorn/workers/ggevent.py", line 152, in handle_request
    super(GeventWorker, self).handle_request(*args)
  File "/virtualenvs/hostedtyr/local/lib/python2.7/site-packages/gunicorn/workers/async.py", line 107, in handle_request
    respiter = self.wsgi(environ, resp.start_response)
  File "/virtualenvs/hostedtyr/local/lib/python2.7/site-packages/falcon/api.py", line 242, in __call__
    responder(req, resp, **params)
  File "/usr/lib/hostedtyr/app.py", line 45, in on_post
    server.resolve_dependencies()
  File "/virtualenvs/hostedtyr/local/lib/python2.7/site-packages/tyr/servers/mongo/node.py", line 84, in resolve_dependencies
    super(MongoNode, self).resolve_dependencies()
  File "/virtualenvs/hostedtyr/local/lib/python2.7/site-packages/tyr/servers/server.py", line 909, in resolve_dependencies
    self.resolve_iam_role()
  File "/virtualenvs/hostedtyr/local/lib/python2.7/site-packages/tyr/servers/server.py", line 658, in resolve_iam_role
    arn = self.iam.get_user().user.arn
  File "/virtualenvs/hostedtyr/local/lib/python2.7/site-packages/boto/iam/connection.py", line 387, in get_user
    return self.get_response('GetUser', params)
  File "/virtualenvs/hostedtyr/local/lib/python2.7/site-packages/boto/iam/connection.py", line 102, in get_response
    raise self.ResponseError(response.status, response.reason, body)
BotoServerError: BotoServerError: 400 Bad Request
<ErrorResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">
  <Error>
    <Type>Sender</Type>
    <Code>ValidationError</Code>
    <Message>Must specify userName when calling with non-User credentials</Message>
  </Error>
  <RequestId>ffe478bd-9ac4-11e7-b66b-37ea99abf1c8</RequestId>
</ErrorResponse>
```

This happens when we build the ARN for IAM Managed Policies. We attempt to retrieve the AWS account ID with
```
iam.get_user()
```
from `boto`, but this doesn't work in this case since it isn't actually an IAM User.

Using

```
 boto3.client('sts').get_caller_identity()
```

retrieves the AWS account ID without relying on the "user" to be an IAM User.