### PR TITLE
update script path

### DIFF
--- a/data/user_data_base_fetch_s3.ps2
+++ b/data/user_data_base_fetch_s3.ps2
@@ -3,7 +3,7 @@
 
 $HUDL_DIRECTORY = "c:\\hudl"
 $USER_DATA_S3_BUCKET = "hudl-chef-artifacts"
-$USER_DATA_S3_KEY = "windows/user_data_base.ps2"
+$USER_DATA_S3_KEY = "windows/user_data_base_no_wrapper.ps2"
 $USER_DATA_FILE_PATH = "c:\\hudl\\user_data_base.ps1"
 
 if(!(Test-Path -Path $HUDL_DIRECTORY )){


### PR DESCRIPTION
The newest version of EC2Config Utility doesn't work with the <powershell></powershell> tags..
I've removed those tags and created a new file. This updates the fetch userdata script to point to the new file