### PR TITLE
Allow for specifying the chef client version in the Tyr request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# CHANGELOG
+
+<https://keepachangelog.com/en/1.0.0/>
+
+## [2.2.0]
+
+- Allow for specifying the Chef client version in the Tyr request
+  - Fixes a bug where a new Ruby gem (`aws-eventstream`) only supports Ruby >= 2.3. Chef Client used this for provisioning, so this broke Tyr provisioning. The Chef version now defaults to 12.14 (where this was fixed) but is configurable via API request.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# Hosted Tyr (v2)
+
+## Internal Hudl documentation
+
+Hudl employees: Check out [Tyr & HostedTyr (v2)](https://sync.hudlnet.com/x/cBlECw) in Hudl Sync for:
+
+- [Sample payloads and API docs](<https://sync.hudlnet.com/pages/viewpage.action?pageId=189012336#Tyr&HostedTyr(v2)-Examples>)
+- [Accessing Tyr instances](<https://sync.hudlnet.com/pages/viewpage.action?pageId=189012336#Tyr&HostedTyr(v2)-AccessingTyrAPIinstance>)
+- Making a change to Tyr and [deploying](<https://sync.hudlnet.com/pages/viewpage.action?pageId=189012336#Tyr&HostedTyr(v2)-DeployingchangestotheAPItoEC2instanceviaDocker>)

--- a/lambda-run_instance_handler/lambda_function.py
+++ b/lambda-run_instance_handler/lambda_function.py
@@ -1,0 +1,93 @@
+import urllib.request
+import json
+import boto3
+import os
+
+ec2 = boto3.client('ec2', region_name='us-east-1')
+s3 = boto3.client('s3')
+
+
+def plant_flag(ticket):
+    return
+
+    s3.put_object(
+        Body='',
+        Bucket=os.environ['S3_OUTPUT_BUCKET'],
+        Key=ticket
+    )
+
+def ticket_in_flight(ticket):
+    return False
+
+    resp = s3.list_objects_v2(
+        Bucket=os.environ['S3_OUTPUT_BUCKET'],
+        MaxKeys=123,
+        Prefix=ticket
+    )
+
+    return len(resp.get('Contents', [])) > 0
+
+
+def provision(event):
+    payload = json.loads(event['Records'][0]['body'])
+
+    if 'ticket' not in payload:
+        raise Exception('No ticket provided')
+
+    ticket = payload['ticket']
+
+    print(f'Recieved ticket {ticket}')
+
+    #if ticket_in_flight(ticket):
+    #    print('Ticket already being processed')
+    #    return
+
+
+    #plant_flag(ticket)
+
+    input_ = payload['input']
+
+    input_['MinCount'] = 1
+    input_['MaxCount'] = 1
+
+    resp = {}
+
+    try:
+        r = ec2.run_instances(**input_)
+
+        print(f'Provisioned instance: {r["Instances"][0]["InstanceId"]}')
+
+        resp['instance_id'] = r['Instances'][0]['InstanceId']
+
+        if len(s3.list_objects_v2(
+            Bucket=os.environ['S3_OUTPUT_BUCKET'],
+            MaxKeys=123,
+            Prefix=ticket
+        ).get('Contents', [])) > 0:
+            return
+    except Exception as ex:
+        resp['error'] = {
+            'message': str(ex),
+            'type': ex.__class__.__name__
+        }
+
+    s3.put_object(
+        Body=json.dumps(resp),
+        Bucket=os.environ['S3_OUTPUT_BUCKET'],
+        Key=payload['ticket']
+    )
+
+def lambda_handler(event, context):
+    try:
+        provision(event)
+    except Exception as ex:
+        s3.put_object(
+            Body=json.dumps({
+                'error': {
+                    'message': str(ex),
+                    'type': ex.__class__.__name__
+                }
+            }),
+            Bucket=os.environ['S3_OUTPUT_BUCKET'],
+            Key='error'
+        )

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import os
 
 setup(
     name='tyr',
-    version='2.1.1',
+    version='2.2.0',
     author='Mihir Singh (@citruspi)',
     author_email='mihir.singh@hudl.com',
     packages=find_packages(),

--- a/tyr/instances/generic.py
+++ b/tyr/instances/generic.py
@@ -54,7 +54,7 @@ class Instance(object):
     @kwarg('keypair', default=lambda kw: Instance.DEFAULT_KEYPAIR_BY_ENV.get(kw['environment'], Instance.DEFAULT_FALLBACK_KEYPAIR))
     @kwarg('security_groups', default=lambda kw: ['management', 'chef-nodes', kw['role'],  f'{kw["environment"][0]}-{kw["server_type"]}-management', f'{kw["environment"][0]}-{kw["group"]}-management'])
     @kwarg('ec2_tags', default={})
-    @kwarg('chef_version', default='12.13.37')
+    @kwarg('chef_version', default='12.14')
     def __init__(self, **kwargs):
         self.__dict__.update(kwargs)
         self.ec2 = aws_client('ec2', region_name=self.region)


### PR DESCRIPTION
## Core change

AWS released a new version of a Ruby gem (`aws-eventstream`) which only supports Ruby >=v2.3. Chef-client uses this gem for things when provisioning a new instance. So the gem upgrade effectively borked chef-client for newly provisioned instances (via Tyr) 

v12.14 of Chef included an upgrade of Ruby and it's only a minor bump away from the version we've been using. 

This PR makes this version configurable, but defaults to the 12.14 version. 

It's been tested so far with provisioning a MongoDb router node.

## Other improvements
- Add Changelog
- Add README with pointer to docs in Sync
- Snapshot code from Hudl's `run_instance_handler` Lambda