### PR TITLE
fix: WS-19394 - Replace Chef Installation Script with patched version we store in S3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 <https://keepachangelog.com/en/1.0.0/>
 
+## [2.4.0]
+- Update the Chef Installation script location to point ot a file we store in S3
+    - Full details about why in [this PR](https://github.com/hudl/hudl-chef-omnitruck-installer/pull/2)
+
 ## [2.3.0]
 
 - Update the bundler version embedded in chef to `1.17.3`.
@@ -9,7 +13,7 @@
       dependencies that are used in the MongoDB provision process and in other
       places as well. You can read more about the prod incident in
       https://sync.hudlnet.com/x/BiT6FQ
-    - Vandelay investigated how to fix this for our role_mongo Cookbook in 
+    - Vandelay investigated how to fix this for our role_mongo Cookbook in
       https://docs.google.com/document/d/11EJwHkUYwzol3HaqnAD8O1YX5lRYI1MTa8AblFPBVs8/edit?usp=sharing
     - The TLDR is we need to update the version of bundler before running chef.
     - To centralise the change in a single place, we are updating Tyr to place

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 <https://keepachangelog.com/en/1.0.0/>
 
 ## [2.4.0]
-- Update the Chef Installation script location to point ot a file we store in S3
+- Update the Chef Installation script location to point at a file we store in S3
     - Full details about why in [this PR](https://github.com/hudl/hudl-chef-omnitruck-installer/pull/2)
 
 ## [2.3.0]

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import os
 
 setup(
     name='tyr',
-    version='2.3.0',
+    version='2.4.0',
     author='Mihir Singh (@citruspi)',
     author_email='mihir.singh@hudl.com',
     packages=find_packages(),

--- a/tyr/instances/generic.py
+++ b/tyr/instances/generic.py
@@ -93,7 +93,11 @@ environment "{chef_env}"
 validation_client_name "hudl-validator"
 ssl_verify_mode :verify_none' > /etc/chef/client.rb
 /usr/bin/aws s3 cp s3://hudl-chef-artifacts/chef-client/encrypted_data_bag_secret /etc/chef/encrypted_data_bag_secret
-curl -L https://omnitruck.chef.io/install.sh | sudo bash -s -- -v {chef_version}
+# This is our own copy of the Chef OmniTruck installation script, see
+# this README for details on why - https://github.com/hudl/hudl-chef-omnitruck-installer/blob/master/README.md
+/usr/bin/aws s3 cp s3://hudl-chef-artifacts/chef-client/install.sh install.sh
+chmod u+x install.sh
+sudo ./install.sh -v {chef_version}
 yum install -y gcc
 printf "%s" "{attributes}" > /etc/chef/attributes.json
 cp /var/tmp/attributes.json /etc/chef/attributes.json


### PR DESCRIPTION
## Overview
* Updating Tyr to use the patched version of the OmniTruck installation script
* For full details on why, see [this PR](https://github.com/hudl/hudl-chef-omnitruck-installer/pull/2) where we applied the patch 
* Tyr can currently provision
    * CouchBase - Dead at Hudl
    * Mongo
    * RabbitMQ
* I spot checked a few Mongo and RabbitMQ IAM roles and they all seem to have the required IAM permissions to pull this file.
    * This file lives in the same location as files the UserData already pulled to bootstrap the instance so the permissions must be correct
* Once this is approved I'll follow [these steps](https://sync.hudlnet.com/pages/viewpage.action?pageId=189012336#Tyr&HostedTyr(v2)-DeployingchangestotheAPItoEC2instanceviaDocker) to deploy a new version of Tyr

## Testing
* I ran these steps manually on a Feed EC2 instance that failed to provision and they worked

```
[root@t-feed-mongo-rs1-use1d-5mlpm1 ~]# /usr/bin/aws s3 cp s3://hudl-chef-artifacts/chef-client/install.sh install.sh
download: s3://hudl-chef-artifacts/chef-client/install.sh to ./install.sh
[root@t-feed-mongo-rs1-use1d-5mlpm1 ~]# chmod u+x install.sh
[root@t-feed-mongo-rs1-use1d-5mlpm1 ~]# sudo ./install.sh -v 12.4
el 6 x86_64
Getting information for chef stable 12.4 for el...
downloading https://omnitruck.chef.io/stable/chef/metadata?v=12.4&p=el&pv=6&m=x86_64
  to file /tmp/install.sh.26322/metadata.txt
trying wget...
sha1	c132e4aba568929f37965ac7f03a3aa036883684
sha256	a011ba87bcd89a02d1cbdffb97a295f753cbb194afef9a1b3b3ca93148fd7808
url	https://packages.chef.io/files/stable/chef/12.4.3/el/6/chef-12.4.3-1.el6.x86_64.rpm
version	12.4.3
downloaded metadata file looks valid...
downloading https://packages.chef.io/files/stable/chef/12.4.3/el/6/chef-12.4.3-1.el6.x86_64.rpm
  to file /tmp/install.sh.26322/chef-12.4.3-1.el6.x86_64.rpm
trying wget...
Comparing checksum with sha256sum...
Installing chef 12.4
installing with rpm...
warning: /tmp/install.sh.26322/chef-12.4.3-1.el6.x86_64.rpm: Header V4 DSA/SHA1 Signature, key ID 83ef826a: NOKEY
Preparing...                          ################################# [100%]
Updating / installing...
   1:chef-12.4.3-1.el6                ################################# [ 50%]
Thank you for installing Chef!
Cleaning up / removing...
   2:chef-12.14.89-1.el6              ################################# [100%]
```